### PR TITLE
execute phpstan CI in custom Docker file

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,13 +16,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Dockerfileからイメージをビルド
+      - name: Build an image from a Dockerfile
         run: docker build --build-arg=PHP_VERSION=${{ matrix.php }} -t phpstan ./docker
 
       - name: Composer install
         run: docker run --rm -v ${{ github.workspace }}:/var/www/html phpstan composer install
 
-      - name: PHPStan実行
+      - name: Execute PHPStan
         run: docker run --rm -v ${{ github.workspace }}:/var/www/html phpstan vendor/bin/phpstan analyse --memory-limit=512M
 
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -17,12 +17,12 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Dockerfileからイメージをビルド
-        run: docker build -t phpstan ./docker
+        run: docker build --build_arg= PHP_VERSION=${{ matrix.php }} -t phpstan ./docker
 
       - name: Composer install
         run: docker run --rm -v ${{ github.workspace }}:/var/www/html phpstan composer install
 
       - name: PHPStan実行
-        run: docker run --rm -v ${{ github.workspace }}:/var/www/html phpstan vendor/bin/phpstan analyse
+        run: docker run --rm -v ${{ github.workspace }}:/var/www/html phpstan vendor/bin/phpstan analyse --memory-limit=512M
 
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,21 +16,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: mongodb, sodium
-          tools: composer:v2
+      - name: Dockerfileからイメージをビルド
+        run: docker build -t phpstan ../../docker/Dockerfile
 
-      - name: Prepare
-        run: composer install
+      - name: Composer install
+        run: docker run --rm -v ${{ github.workspace }}:/var/www/html phpstan composer install
 
-      - name: Versions
-        run: |
-          cat /etc/os-release
-          php -v
-          ./vendor/bin/phpstan --version
-      - name: Execute phpstan
-        run: |
-          ./vendor/bin/phpstan analyse
+      - name: PHPStan実行
+        run: docker run --rm -v ${{ github.workspace }}:/var/www/html phpstan vendor/bin/phpstan analyse
+
+

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Dockerfileからイメージをビルド
-        run: docker build --build_arg= PHP_VERSION=${{ matrix.php }} -t phpstan ./docker
+        run: docker build --build_arg=PHP_VERSION=${{ matrix.php }} -t phpstan ./docker
 
       - name: Composer install
         run: docker run --rm -v ${{ github.workspace }}:/var/www/html phpstan composer install

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -2,9 +2,9 @@ name: phpstan
 
 on:
   pull_request:
-#    paths:
-#      - 'src/**'
-#      - 'tests/**'
+    paths:
+      - 'src/**'
+      - 'tests/**'
 
 jobs:
   phpstan:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Dockerfileからイメージをビルド
-        run: docker build --build_arg=PHP_VERSION=${{ matrix.php }} -t phpstan ./docker
+        run: docker build --build-arg=PHP_VERSION=${{ matrix.php }} -t phpstan ./docker
 
       - name: Composer install
         run: docker run --rm -v ${{ github.workspace }}:/var/www/html phpstan composer install

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -2,9 +2,9 @@ name: phpstan
 
 on:
   pull_request:
-    paths:
-      - 'src/**'
-      - 'tests/**'
+#    paths:
+#      - 'src/**'
+#      - 'tests/**'
 
 jobs:
   phpstan:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Dockerfileからイメージをビルド
-        run: docker build -t phpstan ./docker/Dockerfile
+        run: docker build -t phpstan ./docker
 
       - name: Composer install
         run: docker run --rm -v ${{ github.workspace }}:/var/www/html phpstan composer install

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Dockerfileからイメージをビルド
-        run: docker build -t phpstan ../../docker/Dockerfile
+        run: docker build -t phpstan ./docker/Dockerfile
 
       - name: Composer install
         run: docker run --rm -v ${{ github.workspace }}:/var/www/html phpstan composer install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,11 @@ services:
       - MYSQL_USER=user
       - MYSQL_PASSWORD=password
       - MYSQL_ROOT_PASSWORD=password
+  php:
+    build:
+      context: docker
+      dockerfile: Dockerfile
+    volumes:
+      - .:/var/www/html
+    ports:
+      - 8000:8000

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# ビルド時にPHPバージョンを指定できるように引数を定義
+# Arguments defined so that PHP version can be specified at build time
 ARG PHP_VERSION=8.2
 
 FROM php:${PHP_VERSION}-fpm

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,9 +4,9 @@ ARG PHP_VERSION=8.2
 FROM php:${PHP_VERSION}-fpm
 
 # install php-ext
-#RUN apt-get update && apt-get install -y git wget gnupg vim unzip libxml2-dev libpng-dev libzip-dev libonig-dev default-mysql-client libldap2-dev\
-#  && docker-php-ext-install mbstring dom gd zip pdo_mysql ftp ldap\
-#  && apt-get clean
+RUN apt-get update && apt-get install -y git wget gnupg vim unzip libxml2-dev libpng-dev libzip-dev libonig-dev default-mysql-client libldap2-dev libssl-dev\
+  && docker-php-ext-install mbstring dom gd zip pdo_mysql ftp ldap\
+  && apt-get clean
 
 # install composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM php:8.2-fpm
+
+# install php-ext
+RUN apt-get update && apt-get install -y git wget gnupg vim unzip libxml2-dev libpng-dev libzip-dev libonig-dev default-mysql-client libldap2-dev\
+  && docker-php-ext-install mbstring dom gd zip pdo_mysql ftp ldap\
+  && apt-get clean
+
+# install composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+WORKDIR /var/www/html

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,7 @@
-FROM php:8.2-fpm
+# ビルド時にPHPバージョンを指定できるように引数を定義
+ARG PHP_VERSION=8.2
+
+FROM php:${PHP_VERSION}-fpm
 
 # install php-ext
 RUN apt-get update && apt-get install -y git wget gnupg vim unzip libxml2-dev libpng-dev libzip-dev libonig-dev default-mysql-client libldap2-dev\

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,9 +4,9 @@ ARG PHP_VERSION=8.2
 FROM php:${PHP_VERSION}-fpm
 
 # install php-ext
-RUN apt-get update && apt-get install -y git wget gnupg vim unzip libxml2-dev libpng-dev libzip-dev libonig-dev default-mysql-client libldap2-dev\
-  && docker-php-ext-install mbstring dom gd zip pdo_mysql ftp ldap\
-  && apt-get clean
+#RUN apt-get update && apt-get install -y git wget gnupg vim unzip libxml2-dev libpng-dev libzip-dev libonig-dev default-mysql-client libldap2-dev\
+#  && docker-php-ext-install mbstring dom gd zip pdo_mysql ftp ldap\
+#  && apt-get clean
 
 # install composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -162,7 +162,7 @@ class Admin
     }
 
     /**
-     * Left sider-bar menu.
+     * Left sidebar menu.
      *
      * @return array
      */


### PR DESCRIPTION
##  目的                                                                                                                                                                               
                                                                                                                                                                                     
  - CI 環境の自前管理: 外部 Action (shivammathur/setup-php) への依存を排し、必要な拡張・ライブラリ構成をリポジトリ内 Dockerfile で固定 (再現性とロックインの低減)                    
  - ローカルとの環境統一: 同じ Dockerfile を docker-compose 経由で開発に使えるため、CI 失敗時のローカル再現が容易
  - 加えて src/Admin.php の typo 修正 

##  変更内容                                                                                                                                                                           
                                                                                                                                                                                     
  1. docker/Dockerfile (新規)                                                                                                                                                        
    - php:${PHP_VERSION}-fpm ベースイメージ。PHP_VERSION はビルド時引数 (デフォルト 8.2)
    - apt-get で git/vim/unzip/libxml2/libpng/libzip/libonig/default-mysql-client/libldap2/libssl などを導入                                                                         
    - PHP 拡張: mbstring, dom, gd, zip, pdo_mysql, ftp, ldap                                                                                                                         
    - composer をインストールし、作業ディレクトリは /var/www/html                                                                                                                    
  2. .github/workflows/phpstan.yml                                                                                                                                                   
    - shivammathur/setup-php ステップを廃止                                                                                                                                          
    - 代わりに docker build --build-arg=PHP_VERSION=${{ matrix.php }} -t phpstan ./docker でイメージをビルド
    - composer install と vendor/bin/phpstan analyse --memory-limit=512M を docker run -v ${{ github.workspace }}:/var/www/html で実行                                               
  3. docker-compose.yml                                                                                                                                                              
    - php サービスを追加 (docker/Dockerfile をビルド、ワークスペースをマウント、ポート 8000 公開)                                                                                    
    - これによりローカル開発でも CI と同じイメージを利用可能                                                                                                                         
  4. src/Admin.php                                                                                                                                                                   
    - PHPDoc のタイポ修正: Left sider-bar menu. → Left sidebar menu. (1 行のみ、機能変更なし)                                                                                        
                                                                                                                                                                                     
