### PR TITLE
PHPStan で解決できない Admin ファサードを ignore し、composer の重複スクリプトキーを削除

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,6 @@
     },
     "scripts": {
         "test": "./vendor/bin/phpunit",
-        "phpstan": "./vendor/bin/phpstan analyse",
         "phpcsfixer": "./vendor/bin/php-cs-fixer fix --dry-run",
         "post-autoload-dump": [
             "@php vendor/bin/testbench package:discover --ansi"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,6 +5,8 @@ parameters:
     ignoreErrors:
         - '#Call to static method user\(\) on an unknown class Exment.#'
         - '#Call to static method transaction\(\) on an unknown class ExmentDB.#'
+        - '#Call to static method disablePjax\(\) on an unknown class Admin.#'
+        - '#Call to static method script\(\) on an unknown class Admin.#'
         - '#Access to an undefined property Illuminate\\Database\\Eloquent\\Model::\$id.#'
         - '#Access to an undefined property Illuminate\\Database\\Eloquent\\Model::\$password.#'
         - '#Call to an undefined method Encore\\Admin\\Grid\\Column::pluck\(\).#'


### PR DESCRIPTION
  ## Summary
  
  The PHPStan CI job fails because larastan cannot resolve the global `\Admin`
  facade alias when the package is analyzed in isolation, producing two
  "unknown class Admin" errors:

  - `src/Form/Builder.php:276` — `\Admin::disablePjax()`
  - `src/Widgets/Form.php:714` — `\Admin::script()`

  ## 概要

  PHPStan の CI が失敗していました。larastan がパッケージ単体の解析でグローバルな
  `\Admin` ファサード別名を解決できず、「unknown class Admin」エラーが2件発生するためです。

  - `src/Form/Builder.php:276` — `\Admin::disablePjax()`
  - `src/Widgets/Form.php:714` — `\Admin::script()`