### PR TITLE
[WIP]ci: run all checks on every PR and on merge to master

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -2,9 +2,9 @@ name: php-cs-fixer
 
 on:
   pull_request:
-    paths:
-      - 'src/**'
-      - 'tests/**'
+  push:
+    branches:
+      - master
 
 jobs:
   php-cs-fixer:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -2,9 +2,9 @@ name: phpstan
 
 on:
   pull_request:
-    paths:
-      - 'src/**'
-      - 'tests/**'
+  push:
+    branches:
+      - master
 
 jobs:
   phpstan:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -2,12 +2,9 @@ name: unittest
 
 on:
   pull_request:
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'resources/**'
-      - 'database/**'
-      - 'config/**'
+  push:
+    branches:
+      - master
 
 jobs:
   unittest:


### PR DESCRIPTION
## Summary / 概要

**EN:** Make the `phpstan`, `php-cs-fixer` and `unittest` workflows run on **every** pull request and on **push to `master`**, so CI is never silently skipped. This is a follow-up to #44, where a PHPStan failure was not caught because the checks did not run on the merge.

**JA:** `phpstan` / `php-cs-fixer` / `unittest` の各ワークフローを **すべてのPR** と **`master` への push（マージ）** で実行するようにします。#44 で、マージ時にチェックが走らず PHPStan の失敗を検知できなかったことへの再発防止です。

## Changes / 変更内容

- **Remove `paths:` filters / `paths:` フィルタを撤廃**
  - EN: Checks now run on every PR regardless of which files changed, preventing the silent skip that occurs when changed files don't match the filter.
  - JA: 変更ファイルに関わらず全PRでチェックが走るようになり、パス不一致による無言スキップを防止します。
- **Add `push: branches: [master]` / `push` トリガーを追加**
  - EN: The merged result on `master` is verified right after merge.
  - JA: マージ後の `master` でもチェックが走り、マージ結果を検証します。

```yaml
on:
  pull_request:
  push:
    branches:
      - master
```

## Notes / 補足

- **EN:** This makes checks *run*, but does not *block* a bad merge by itself. True prevention requires **branch protection → Required status checks** (`phpstan`, `php-cs-fixer`, `unittest`) on `master`. Removing the `paths:` filters is also a prerequisite for that, since path-filtered required checks can leave a PR permanently un-mergeable.
- **JA:** これでチェックは「走る」ようになりますが、それ自体は壊れたマージを「ブロック」しません。恒久対策には `master` の **ブランチ保護 → Required status checks**（`phpstan` / `php-cs-fixer` / `unittest`）の設定が必要です。`paths:` 撤廃はその前提でもあります（パスフィルタ付き必須チェックはPRが永久にマージ不能になる不具合があるため）。
- **EN/JA:** Trade-off: doc-only PRs will now also run `unittest` (MySQL, ~3 min), increasing CI usage. / ドキュメントのみのPRでも `unittest`（MySQL・約3分）が走るため、CI使用量は増えます。