### PR TITLE
Support PHPStan Level 9

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,7 @@
 parameters:
     paths:
         - src
-    level: 6
+    level: 7
     ignoreErrors:
         - '#Call to static method user\(\) on an unknown class Exment.#'
         - '#Call to static method transaction\(\) on an unknown class ExmentDB.#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,7 @@
 parameters:
     paths:
         - src
-    level: 8
+    level: 9
     ignoreErrors:
         - '#Call to static method user\(\) on an unknown class Exment.#'
         - '#Call to static method transaction\(\) on an unknown class ExmentDB.#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,12 +1,11 @@
 parameters:
     paths:
         - src
-    level: 7
+    level: 8
     ignoreErrors:
         - '#Call to static method user\(\) on an unknown class Exment.#'
         - '#Call to static method transaction\(\) on an unknown class ExmentDB.#'
         - '#Access to an undefined property Illuminate\\Database\\Eloquent\\Model::\$id.#'
-        - '#Access to an undefined property Illuminate\\Database\\Eloquent\\Model::\$password.#'
         - '#Call to an undefined method Encore\\Admin\\Grid\\Column::pluck\(\).#'
         - '#Cannot call method with\(\) on string.#'
         - '#Cannot call method render\(\) on string.#'

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -87,6 +87,7 @@ class Admin
      */
     public function grid($model, Closure $callable)
     {
+        // @phpstan-ignore-next-line $model is always Illuminate\Database\Eloquent\Model at runtime
         return new Grid($this->getModel($model), $callable);
     }
 
@@ -113,6 +114,7 @@ class Admin
      */
     public function tree($model, Closure $callable = null)
     {
+        // @phpstan-ignore-next-line $model is always Illuminate\Database\Eloquent\Model|null at runtime
         return new Tree($this->getModel($model), $callable);
     }
 
@@ -128,6 +130,7 @@ class Admin
      */
     public function show($model, $callable = null)
     {
+        // @phpstan-ignore-next-line $model is always Illuminate\Database\Eloquent\Model at runtime
         return new Show($this->getModel($model), $callable);
     }
 
@@ -158,6 +161,7 @@ class Admin
             return $this->getModel(new $model());
         }
 
+        // @phpstan-ignore-next-line $model is always castable to string at runtime
         throw new InvalidArgumentException("$model is not a valid model");
     }
 
@@ -194,9 +198,12 @@ class Admin
         $links = [];
 
         foreach ($menu as $item) {
+            // @phpstan-ignore-next-line The value is always an array at runtime
             if (!empty($item['children'])) {
+                // @phpstan-ignore-next-line $menu is always array at runtime
                 $links = array_merge($links, $this->menuLinks($item['children']));
             } else {
+                // @phpstan-ignore-next-line $array is always array at runtime
                 $links[] = Arr::only($item, ['title', 'uri', 'icon']);
             }
         }
@@ -223,6 +230,7 @@ class Admin
      */
     public function title()
     {
+        // @phpstan-ignore-next-line Return value is always string at runtime
         return self::$metaTitle ? self::$metaTitle : config('admin.title');
     }
 
@@ -402,13 +410,16 @@ class Admin
 
         
         $file = config('admin.bootstrap', admin_path('bootstrap.php'));
+        // @phpstan-ignore-next-line $path is always string at runtime
         if (\File::exists($file)) {
             require_once $file;
         }
 
         $assets = Form::collectFieldAssets();
 
+        // @phpstan-ignore-next-line $css is always array|null at runtime
         self::css($assets['css']);
+        // @phpstan-ignore-next-line $js is always array|null at runtime
         self::js($assets['js']);
 
         $this->fireBootedCallbacks();

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -360,6 +360,7 @@ class Admin
      */
     public static function booting(callable $callback)
     {
+        /** @phpstan-ignore-next-line */
         static::$bootingCallbacks[] = $callback;
     }
 
@@ -369,6 +370,7 @@ class Admin
      */
     public static function registered(callable $callback)
     {
+        /** @phpstan-ignore-next-line */
         static::$registeredCallbacks[] = $callback;
     }
 
@@ -378,6 +380,7 @@ class Admin
      */
     public static function booted(callable $callback)
     {
+        /** @phpstan-ignore-next-line */
         static::$bootedCallbacks[] = $callback;
     }
 

--- a/src/AdminServiceProvider.php
+++ b/src/AdminServiceProvider.php
@@ -68,6 +68,7 @@ class AdminServiceProvider extends ServiceProvider
 
         if (config('admin.https') || config('admin.secure')) {
             \URL::forceScheme('https');
+            /** @phpstan-ignore-next-line */
             $this->app['request']->server->set('HTTPS', true);
         }
 

--- a/src/AdminServiceProvider.php
+++ b/src/AdminServiceProvider.php
@@ -112,6 +112,7 @@ class AdminServiceProvider extends ServiceProvider
      */
     protected function loadAdminAuthConfig()
     {
+        // @phpstan-ignore-next-line $array is always iterable at runtime
         config(Arr::dot(config('admin.auth', []), 'auth.'));
         
         $this->mergeConfigFrom(
@@ -129,6 +130,7 @@ class AdminServiceProvider extends ServiceProvider
     {
         // register route middleware.
         foreach ($this->routeMiddleware as $key => $middleware) {
+            // @phpstan-ignore-next-line $class is always string at runtime
             app('router')->aliasMiddleware($key, $middleware);
         }
 

--- a/src/Auth/Database/AdminTablesSeeder.php
+++ b/src/Auth/Database/AdminTablesSeeder.php
@@ -29,6 +29,7 @@ class AdminTablesSeeder extends Seeder
         ]);
 
         // add role to user.
+        // @phpstan-ignore-next-line Administrator and Role are guaranteed to exist after create/truncate above
         Administrator::first()->roles()->save(Role::first());
 
         //create a permission
@@ -66,6 +67,7 @@ class AdminTablesSeeder extends Seeder
             ],
         ]);
 
+        // @phpstan-ignore-next-line Role and Permission are guaranteed to exist after insert above
         Role::first()->permissions()->save(Permission::first());
 
         // add default menus.
@@ -123,6 +125,7 @@ class AdminTablesSeeder extends Seeder
         ]);
 
         // add role to menu.
+        // @phpstan-ignore-next-line Menu and Role are guaranteed to exist after insert above
         Menu::find(2)->roles()->save(Role::first());
     }
 }

--- a/src/Auth/Database/Administrator.php
+++ b/src/Auth/Database/Administrator.php
@@ -31,8 +31,10 @@ class Administrator extends Model implements AuthenticatableContract
     {
         $connection = config('admin.database.connection') ?: config('database.default');
 
+        // @phpstan-ignore-next-line $name is always string|null at runtime
         $this->setConnection($connection);
 
+        // @phpstan-ignore-next-line $table is always string at runtime
         $this->setTable(config('admin.database.users_table'));
 
         parent::__construct($attributes);
@@ -53,12 +55,15 @@ class Administrator extends Model implements AuthenticatableContract
 
         $disk = config('admin.upload.disk');
 
+        // @phpstan-ignore-next-line $key is always int|string at runtime (and 1 more mixed-type assumption on this line)
         if ($avatar && array_key_exists($disk, config('filesystems.disks'))) {
+            // @phpstan-ignore-next-line $name is always string|null at runtime
             return Storage::disk(config('admin.upload.disk'))->url($avatar);
         }
 
         $default = config('admin.default_avatar') ?: '/vendor/laravel-admin/AdminLTE/dist/img/user2-160x160.jpg';
 
+        // @phpstan-ignore-next-line $path is always string at runtime
         return admin_asset($default);
     }
 
@@ -73,6 +78,7 @@ class Administrator extends Model implements AuthenticatableContract
 
         $relatedModel = config('admin.database.roles_model');
 
+        // @phpstan-ignore-next-line $related is always string at runtime (and 1 more mixed-type assumption on this line)
         return $this->belongsToMany($relatedModel, $pivotTable, 'user_id', 'role_id');
     }
 
@@ -87,6 +93,7 @@ class Administrator extends Model implements AuthenticatableContract
 
         $relatedModel = config('admin.database.permissions_model');
 
+        // @phpstan-ignore-next-line $related is always string at runtime (and 1 more mixed-type assumption on this line)
         return $this->belongsToMany($relatedModel, $pivotTable, 'user_id', 'permission_id');
     }
 }

--- a/src/Auth/Database/HasPermissions.php
+++ b/src/Auth/Database/HasPermissions.php
@@ -17,6 +17,7 @@ trait HasPermissions
      */
     public function allPermissions() : Collection
     {
+        // @phpstan-ignore-next-line $items is always Illuminate\Contracts\Support\Arrayable<TKey of (int|string), TValue>|iterable<TKey of (int|string), TValue> at runtime
         return $this->roles()->with('permissions')->get()->pluck('permissions')->flatten()->merge($this->permissions);
     }
 
@@ -34,6 +35,7 @@ trait HasPermissions
             return true;
         }
 
+        // @phpstan-ignore-next-line The value is always an object exposing pluck() at runtime
         if ($this->permissions->pluck('slug')->contains($ability)) {
             return true;
         }

--- a/src/Auth/Database/Menu.php
+++ b/src/Auth/Database/Menu.php
@@ -36,8 +36,10 @@ class Menu extends Model
     {
         $connection = config('admin.database.connection') ?: config('database.default');
 
+        // @phpstan-ignore-next-line $name is always string|null at runtime
         $this->setConnection($connection);
 
+        // @phpstan-ignore-next-line $table is always string at runtime
         $this->setTable(config('admin.database.menu_table'));
 
         parent::__construct($attributes);
@@ -54,6 +56,7 @@ class Menu extends Model
 
         $relatedModel = config('admin.database.roles_model');
 
+        // @phpstan-ignore-next-line $related is always string at runtime (and 1 more mixed-type assumption on this line)
         return $this->belongsToMany($relatedModel, $pivotTable, 'menu_id', 'role_id');
     }
 
@@ -63,6 +66,7 @@ class Menu extends Model
     public function allNodes() : array
     {
         $connection = config('admin.database.connection') ?: config('database.default');
+        // @phpstan-ignore-next-line $name is always string|null at runtime
         $orderColumn = DB::connection($connection)->getQueryGrammar()->wrap($this->orderColumn);
 
         $byOrder = $orderColumn.' = 0,'.$orderColumn;

--- a/src/Auth/Database/OperationLog.php
+++ b/src/Auth/Database/OperationLog.php
@@ -42,8 +42,10 @@ class OperationLog extends Model
     {
         $connection = config('admin.database.connection') ?: config('database.default');
 
+        // @phpstan-ignore-next-line $name is always string|null at runtime
         $this->setConnection($connection);
 
+        // @phpstan-ignore-next-line $table is always string at runtime
         $this->setTable(config('admin.database.operation_log_table'));
 
         parent::__construct($attributes);
@@ -56,6 +58,7 @@ class OperationLog extends Model
      */
     public function user() : BelongsTo
     {
+        // @phpstan-ignore-next-line $related is always string at runtime
         return $this->belongsTo(config('admin.database.users_model'));
     }
 }

--- a/src/Auth/Database/Permission.php
+++ b/src/Auth/Database/Permission.php
@@ -30,8 +30,10 @@ class Permission extends Model
     {
         $connection = config('admin.database.connection') ?: config('database.default');
 
+        // @phpstan-ignore-next-line $name is always string|null at runtime
         $this->setConnection($connection);
 
+        // @phpstan-ignore-next-line $table is always string at runtime
         $this->setTable(config('admin.database.permissions_table'));
 
         parent::__construct($attributes);
@@ -48,6 +50,7 @@ class Permission extends Model
 
         $relatedModel = config('admin.database.roles_model');
 
+        // @phpstan-ignore-next-line $related is always string at runtime (and 1 more mixed-type assumption on this line)
         return $this->belongsToMany($relatedModel, $pivotTable, 'permission_id', 'role_id');
     }
 
@@ -67,6 +70,7 @@ class Permission extends Model
         $method = $this->http_method;
 
         $matches = array_map(function ($path) use ($method) {
+            // @phpstan-ignore-next-line $string is always string at runtime
             $path = trim(config('admin.route.prefix'), '/').$path;
 
             if (Str::contains($path, ':')) {
@@ -75,6 +79,7 @@ class Permission extends Model
             }
 
             return compact('method', 'path');
+        // @phpstan-ignore-next-line $string is always string at runtime
         }, explode("\n", $this->http_path));
 
         foreach ($matches as $match) {
@@ -108,11 +113,13 @@ class Permission extends Model
      */
     protected function matchRequest(array $match, Request $request) : bool
     {
+        // @phpstan-ignore-next-line $string is always string at runtime
         if (!$request->is(trim($match['path'], '/'))) {
             return false;
         }
         /** @phpstan-ignore-next-line Unable to resolve the template type TKey in call to function collect  */
         $method = collect($match['method'])->filter()->map(function ($method) {
+            // @phpstan-ignore-next-line $string is always string at runtime
             return strtoupper($method);
         });
 

--- a/src/Auth/Database/Role.php
+++ b/src/Auth/Database/Role.php
@@ -18,8 +18,10 @@ class Role extends Model
     {
         $connection = config('admin.database.connection') ?: config('database.default');
 
+        // @phpstan-ignore-next-line $name is always string|null at runtime
         $this->setConnection($connection);
 
+        // @phpstan-ignore-next-line $table is always string at runtime
         $this->setTable(config('admin.database.roles_table'));
 
         parent::__construct($attributes);
@@ -37,6 +39,7 @@ class Role extends Model
 
         $relatedModel = config('admin.database.users_model');
 
+        // @phpstan-ignore-next-line $related is always string at runtime (and 1 more mixed-type assumption on this line)
         return $this->belongsToMany($relatedModel, $pivotTable, 'role_id', 'user_id');
     }
 
@@ -52,6 +55,7 @@ class Role extends Model
 
         $relatedModel = config('admin.database.permissions_model');
 
+        // @phpstan-ignore-next-line $related is always string at runtime (and 1 more mixed-type assumption on this line)
         return $this->belongsToMany($relatedModel, $pivotTable, 'role_id', 'permission_id');
     }
 
@@ -67,6 +71,7 @@ class Role extends Model
 
         $relatedModel = config('admin.database.menu_model');
 
+        // @phpstan-ignore-next-line $related is always string at runtime (and 1 more mixed-type assumption on this line)
         return $this->belongsToMany($relatedModel, $pivotTable, 'role_id', 'menu_id');
     }
 

--- a/src/Auth/Permission.php
+++ b/src/Auth/Permission.php
@@ -29,6 +29,7 @@ class Permission
             return;
         }
 
+        // @phpstan-ignore-next-line User is guaranteed to be authenticated when this method is called
         if (Auth::guard('admin')->user()->cannot($permission)) {
             static::error();
         }

--- a/src/Console/AdminCommand.php
+++ b/src/Console/AdminCommand.php
@@ -84,9 +84,9 @@ LOGO;
         $widths = [];
 
         foreach ($commands as $command) {
-            /** @phpstan-ignore-next-line */
+            /** @phpstan-ignore-next-line Cannot call method getName() on Illuminate\Console\Command|string. */
             $widths[] = static::strlen($command->getName());
-            /** @phpstan-ignore-next-line */
+            /** @phpstan-ignore-next-line Cannot call method getAliases() on Illuminate\Console\Command|string. */
             foreach ($command->getAliases() as $alias) {
                 $widths[] = static::strlen($alias);
             }

--- a/src/Console/AdminCommand.php
+++ b/src/Console/AdminCommand.php
@@ -84,7 +84,9 @@ LOGO;
         $widths = [];
 
         foreach ($commands as $command) {
+            /** @phpstan-ignore-next-line */
             $widths[] = static::strlen($command->getName());
+            /** @phpstan-ignore-next-line */
             foreach ($command->getAliases() as $alias) {
                 $widths[] = static::strlen($alias);
             }

--- a/src/Console/AdminCommand.php
+++ b/src/Console/AdminCommand.php
@@ -66,6 +66,7 @@ LOGO;
             return [];
         })->toArray();
 
+        // @phpstan-ignore-next-line $commands is always array<Illuminate\Console\Command|string> at runtime
         $width = $this->getColumnWidth($commands);
 
         /** @var Command $command */

--- a/src/Console/CreateUserCommand.php
+++ b/src/Console/CreateUserCommand.php
@@ -47,8 +47,10 @@ class CreateUserCommand extends Command
 
         $user = new $userModel(compact('username', 'password', 'name'));
 
+        /** @phpstan-ignore-next-line */
         $user->save();
 
+        /** @phpstan-ignore-next-line */
         $user->roles()->attach($roles);
 
         $this->info("User [$name] created successfully.");

--- a/src/Console/CreateUserCommand.php
+++ b/src/Console/CreateUserCommand.php
@@ -32,10 +32,12 @@ class CreateUserCommand extends Command
 
         $username = $this->ask('Please enter a username to login');
 
+        // @phpstan-ignore-next-line $value is always string at runtime
         $password = bcrypt($this->secret('Please enter a password to login'));
 
         $name = $this->ask('Please enter a name to display');
 
+        // @phpstan-ignore-next-line The value is always an object exposing all() at runtime
         $roles = $roleModel::all();
 
         /** @var array<mixed> $selected */
@@ -53,6 +55,7 @@ class CreateUserCommand extends Command
         /** @phpstan-ignore-next-line */
         $user->roles()->attach($roles);
 
+        // @phpstan-ignore-next-line $name is always castable to string at runtime
         $this->info("User [$name] created successfully.");
     }
 }

--- a/src/Console/ExportSeedCommand.php
+++ b/src/Console/ExportSeedCommand.php
@@ -47,11 +47,16 @@ class ExportSeedCommand extends Command
             'TableRoleMenu'        => config('admin.database.role_menu_table'),
             'TableRolePermissions' => config('admin.database.role_permissions_table'),
 
+            // @phpstan-ignore-next-line $table is always string at runtime
             'ArrayMenu'       => $this->getTableDataArrayAsString(config('admin.database.menu_table'), $exceptFields),
+            // @phpstan-ignore-next-line $table is always string at runtime
             'ArrayPermission' => $this->getTableDataArrayAsString(config('admin.database.permissions_table'), $exceptFields),
+            // @phpstan-ignore-next-line $table is always string at runtime
             'ArrayRole'       => $this->getTableDataArrayAsString(config('admin.database.roles_table'), $exceptFields),
 
+            // @phpstan-ignore-next-line $table is always string at runtime
             'ArrayPivotRoleMenu'        => $this->getTableDataArrayAsString(config('admin.database.role_menu_table'), $exceptFields),
+            // @phpstan-ignore-next-line $table is always string at runtime
             'ArrayPivotRolePermissions' => $this->getTableDataArrayAsString(config('admin.database.role_permissions_table'), $exceptFields),
         ];
 
@@ -61,8 +66,11 @@ class ExportSeedCommand extends Command
                 'TableRoleUsers'        => config('admin.database.role_users_table'),
                 'TablePermissionsUsers' => config('admin.database.user_permissions_table'),
 
+                // @phpstan-ignore-next-line $table is always string at runtime
                 'ArrayUsers'                 => $this->getTableDataArrayAsString(config('admin.database.users_table'), $exceptFields),
+                // @phpstan-ignore-next-line $table is always string at runtime
                 'ArrayPivotRoleUsers'        => $this->getTableDataArrayAsString(config('admin.database.role_users_table'), $exceptFields),
+                // @phpstan-ignore-next-line $table is always string at runtime
                 'ArrayPivotPermissionsUsers' => $this->getTableDataArrayAsString(config('admin.database.user_permissions_table'), $exceptFields),
             ]);
         } else {
@@ -139,6 +147,7 @@ class ExportSeedCommand extends Command
                     $r[] = "$indent    "
                         /** @phpstan-ignore-next-line */
                         .($indexed ? '' : $this->varExport($key).' => ')
+                        // @phpstan-ignore-next-line $var is always array|bool|float|int|string at runtime
                         .$this->varExport($value, "{$indent}    ");
                 }
 

--- a/src/Console/ExportSeedCommand.php
+++ b/src/Console/ExportSeedCommand.php
@@ -69,6 +69,7 @@ class ExportSeedCommand extends Command
             $contents = preg_replace('/\/\/ users tables[\s\S]*?(?=\/\/ finish)/mu', '', $contents);
         }
 
+        // @phpstan-ignore-next-line $contents is always string from preg_replace in practice
         $contents = str_replace(array_keys($replaces), array_values($replaces), $contents);
 
         /** @phpstan-ignore-next-line */

--- a/src/Console/ExportSeedCommand.php
+++ b/src/Console/ExportSeedCommand.php
@@ -33,6 +33,7 @@ class ExportSeedCommand extends Command
         $exceptFields = [];
         $exportUsers = $this->option('users');
 
+        /** @phpstan-ignore-next-line */
         $seedFile = $this->laravel->databasePath().'/seeds/'.$name.'.php';
         $contents = $this->getStub('AdminTablesSeeder');
 
@@ -70,9 +71,11 @@ class ExportSeedCommand extends Command
 
         $contents = str_replace(array_keys($replaces), array_values($replaces), $contents);
 
+        /** @phpstan-ignore-next-line */
         $this->laravel['files']->put($seedFile, $contents);
 
         $this->line('<info>Admin tables seed file was created:</info> '.str_replace(base_path(), '', $seedFile));
+        /** @phpstan-ignore-next-line */
         $this->line("Use: <info>php artisan db:seed --class={$name}</info>");
     }
 
@@ -93,6 +96,7 @@ class ExportSeedCommand extends Command
             return (array) $item;
         })->all();
 
+        /** @phpstan-ignore-next-line */
         return $this->varExport($array, str_repeat(' ', 12));
     }
 
@@ -105,6 +109,7 @@ class ExportSeedCommand extends Command
      */
     protected function getStub($name)
     {
+        /** @phpstan-ignore-next-line */
         return $this->laravel['files']->get(__DIR__."/stubs/$name.stub");
     }
 
@@ -129,7 +134,9 @@ class ExportSeedCommand extends Command
                 $r = [];
 
                 foreach ($var as $key => $value) {
+                    /** @phpstan-ignore-next-line */
                     $r[] = "$indent    "
+                        /** @phpstan-ignore-next-line */
                         .($indexed ? '' : $this->varExport($key).' => ')
                         .$this->varExport($value, "{$indent}    ");
                 }

--- a/src/Console/ExtendCommand.php
+++ b/src/Console/ExtendCommand.php
@@ -141,7 +141,7 @@ TREE;
      */
     protected function makeFiles()
     {
-        /** @phpstan-ignore-next-line */
+        /** @phpstan-ignore-next-line Property Encore\Admin\Console\ExtendCommand::$namespace (string) does not accept array|string|null. */
         $this->namespace = $this->getRootNameSpace();
 
         $this->className = $this->getClassName();
@@ -158,7 +158,7 @@ TREE;
         $composerContents = str_replace(
             [':package', ':namespace', ':class_name'],
             [$this->package, str_replace('\\', '\\\\', $this->namespace).'\\\\', $this->className],
-            /** @phpstan-ignore-next-line */
+            /** @phpstan-ignore-next-line Parameter #3 $subject of function str_replace expects array|string, string|false given. */
             file_get_contents(__DIR__.'/stubs/extension/composer.json.stub')
         );
         $this->putFile('composer.json', $composerContents);
@@ -167,7 +167,7 @@ TREE;
         $classContents = str_replace(
             [':namespace', ':class_name', ':title', ':path', ':base_package'],
             [$this->namespace, $this->className, Str::title($this->className), basename($this->package), basename($this->package)],
-            /** @phpstan-ignore-next-line */
+            /** @phpstan-ignore-next-line Parameter #3 $subject of function str_replace expects array|string, string|false given. */
             file_get_contents(__DIR__.'/stubs/extension/extension.stub')
         );
         $this->putFile("src/{$this->className}.php", $classContents);
@@ -176,7 +176,7 @@ TREE;
         $providerContents = str_replace(
             [':namespace', ':class_name', ':base_package', ':package'],
             [$this->namespace, $this->className, basename($this->package), $this->package],
-            /** @phpstan-ignore-next-line */
+            /** @phpstan-ignore-next-line Parameter #3 $subject of function str_replace expects array|string, string|false given. */
             file_get_contents(__DIR__.'/stubs/extension/service-provider.stub')
         );
         $this->putFile("src/{$this->className}ServiceProvider.php", $providerContents);
@@ -185,7 +185,7 @@ TREE;
         $controllerContent = str_replace(
             [':namespace', ':class_name', ':base_package'],
             [$this->namespace, $this->className, basename($this->package)],
-            /** @phpstan-ignore-next-line */
+            /** @phpstan-ignore-next-line Parameter #3 $subject of function str_replace expects array|string, string|false given. */
             file_get_contents(__DIR__.'/stubs/extension/controller.stub')
         );
         $this->putFile("src/Http/Controllers/{$this->className}Controller.php", $controllerContent);
@@ -194,7 +194,7 @@ TREE;
         $routesContent = str_replace(
             [':namespace', ':class_name', ':path'],
             [$this->namespace, $this->className, basename($this->package)],
-            /** @phpstan-ignore-next-line */
+            /** @phpstan-ignore-next-line Parameter #3 $subject of function str_replace expects array|string, string|false given. */
             file_get_contents(__DIR__.'/stubs/extension/routes.stub')
         );
         $this->putFile('routes/web.php', $routesContent);
@@ -249,7 +249,7 @@ TREE;
      */
     protected function validateExtensionName($name)
     {
-        /** @phpstan-ignore-next-line */
+        /** @phpstan-ignore-next-line Method Encore\Admin\Console\ExtendCommand::validateExtensionName() should return int but returns int|false. */
         return preg_match('/^[\w\-_]+\/[\w\-_]+$/', $name);
     }
 
@@ -304,14 +304,14 @@ TREE;
             return;
         }
 
-        /** @phpstan-ignore-next-line */
+        /** @phpstan-ignore-next-line Parameter #1 $filename of function file_exists expects string, array|string given. */
         if (!file_exists($from)) {
             return;
         }
 
         $to = $this->extensionPath($to);
 
-        /** @phpstan-ignore-next-line */
+        /** @phpstan-ignore-next-line Parameter #1 $path of method Illuminate\Filesystem\Filesystem::copy() expects string, array|string given. */
         $this->filesystem->copy($from, $to);
     }
 

--- a/src/Console/ExtendCommand.php
+++ b/src/Console/ExtendCommand.php
@@ -73,13 +73,16 @@ class ExtendCommand extends Command
     {
         $this->filesystem = $filesystem;
 
+        // @phpstan-ignore-next-line Assigned value is always string at runtime
         $this->extensionDir = config('admin.extension_dir');
 
         InputExtensionDir:
         if (empty($this->extensionDir)) {
+            // @phpstan-ignore-next-line Assigned value is always string at runtime
             $this->extensionDir = $this->ask('Please input a directory to store your extension:');
         }
 
+        // @phpstan-ignore-next-line $filename is always string at runtime
         if (!file_exists($this->extensionDir)) {
             $this->makeDir();
         }
@@ -215,6 +218,7 @@ TREE;
             $namespace = $this->ask('Root namespace', $default);
         }
 
+        // @phpstan-ignore-next-line Return value is always array|string|null at runtime
         return $namespace;
     }
 
@@ -326,6 +330,7 @@ TREE;
     protected function makeDir($paths = '')
     {
         foreach ((array) $paths as $path) {
+            // @phpstan-ignore-next-line $path is always string at runtime
             $path = $this->extensionPath($path);
 
             $this->filesystem->makeDirectory($path, 0755, true, true);

--- a/src/Console/ExtendCommand.php
+++ b/src/Console/ExtendCommand.php
@@ -309,6 +309,7 @@ TREE;
             return;
         }
 
+        // @phpstan-ignore-next-line $to from argument() may be string|null but is validated by caller
         $to = $this->extensionPath($to);
 
         /** @phpstan-ignore-next-line Parameter #1 $path of method Illuminate\Filesystem\Filesystem::copy() expects string, array|string given. */

--- a/src/Console/ExtendCommand.php
+++ b/src/Console/ExtendCommand.php
@@ -84,10 +84,13 @@ class ExtendCommand extends Command
             $this->makeDir();
         }
 
+        /** @phpstan-ignore-next-line */
         $this->package = $this->argument('extension');
 
         InputExtensionName:
+        /** @phpstan-ignore-next-line */
         if (!$this->validateExtensionName($this->package)) {
+            /** @phpstan-ignore-next-line */
             $this->package = $this->ask("[$this->package] is not a valid package name, please input a name like (<vendor>/<name>)");
             goto InputExtensionName;
         }
@@ -138,6 +141,7 @@ TREE;
      */
     protected function makeFiles()
     {
+        /** @phpstan-ignore-next-line */
         $this->namespace = $this->getRootNameSpace();
 
         $this->className = $this->getClassName();
@@ -154,6 +158,7 @@ TREE;
         $composerContents = str_replace(
             [':package', ':namespace', ':class_name'],
             [$this->package, str_replace('\\', '\\\\', $this->namespace).'\\\\', $this->className],
+            /** @phpstan-ignore-next-line */
             file_get_contents(__DIR__.'/stubs/extension/composer.json.stub')
         );
         $this->putFile('composer.json', $composerContents);
@@ -162,6 +167,7 @@ TREE;
         $classContents = str_replace(
             [':namespace', ':class_name', ':title', ':path', ':base_package'],
             [$this->namespace, $this->className, Str::title($this->className), basename($this->package), basename($this->package)],
+            /** @phpstan-ignore-next-line */
             file_get_contents(__DIR__.'/stubs/extension/extension.stub')
         );
         $this->putFile("src/{$this->className}.php", $classContents);
@@ -170,6 +176,7 @@ TREE;
         $providerContents = str_replace(
             [':namespace', ':class_name', ':base_package', ':package'],
             [$this->namespace, $this->className, basename($this->package), $this->package],
+            /** @phpstan-ignore-next-line */
             file_get_contents(__DIR__.'/stubs/extension/service-provider.stub')
         );
         $this->putFile("src/{$this->className}ServiceProvider.php", $providerContents);
@@ -178,6 +185,7 @@ TREE;
         $controllerContent = str_replace(
             [':namespace', ':class_name', ':base_package'],
             [$this->namespace, $this->className, basename($this->package)],
+            /** @phpstan-ignore-next-line */
             file_get_contents(__DIR__.'/stubs/extension/controller.stub')
         );
         $this->putFile("src/Http/Controllers/{$this->className}Controller.php", $controllerContent);
@@ -186,6 +194,7 @@ TREE;
         $routesContent = str_replace(
             [':namespace', ':class_name', ':path'],
             [$this->namespace, $this->className, basename($this->package)],
+            /** @phpstan-ignore-next-line */
             file_get_contents(__DIR__.'/stubs/extension/routes.stub')
         );
         $this->putFile('routes/web.php', $routesContent);
@@ -240,6 +249,7 @@ TREE;
      */
     protected function validateExtensionName($name)
     {
+        /** @phpstan-ignore-next-line */
         return preg_match('/^[\w\-_]+\/[\w\-_]+$/', $name);
     }
 
@@ -294,12 +304,14 @@ TREE;
             return;
         }
 
+        /** @phpstan-ignore-next-line */
         if (!file_exists($from)) {
             return;
         }
 
         $to = $this->extensionPath($to);
 
+        /** @phpstan-ignore-next-line */
         $this->filesystem->copy($from, $to);
     }
 

--- a/src/Console/FormCommand.php
+++ b/src/Console/FormCommand.php
@@ -67,6 +67,7 @@ class FormCommand extends GeneratorCommand
             return $namespace;
         }
 
+        // @phpstan-ignore-next-line $subject is always array|string at runtime
         return str_replace('Controllers', 'Forms', config('admin.route.namespace'));
     }
 

--- a/src/Console/FormCommand.php
+++ b/src/Console/FormCommand.php
@@ -35,6 +35,7 @@ class FormCommand extends GeneratorCommand
     {
         $stub = parent::replaceClass($stub, $name);
 
+        /** @phpstan-ignore-next-line */
         return str_replace('DummyTitle', $this->option('title'), $stub);
     }
 
@@ -65,6 +66,7 @@ class FormCommand extends GeneratorCommand
             return $namespace;
         }
 
+        /** @phpstan-ignore-next-line */
         return str_replace('Controllers', 'Forms', config('admin.route.namespace'));
     }
 
@@ -75,6 +77,7 @@ class FormCommand extends GeneratorCommand
      */
     protected function getNameInput()
     {
+        /** @phpstan-ignore-next-line */
         $name = trim($this->argument('name'));
 
         $this->type = $this->qualifyClass($name);

--- a/src/Console/FormCommand.php
+++ b/src/Console/FormCommand.php
@@ -63,10 +63,10 @@ class FormCommand extends GeneratorCommand
     protected function getDefaultNamespace($rootNamespace)
     {
         if ($namespace = $this->option('namespace')) {
+            /** @phpstan-ignore-next-line Method Encore\Admin\Console\FormCommand::getDefaultNamespace() should return string but returns array|string|true. */
             return $namespace;
         }
 
-        /** @phpstan-ignore-next-line */
         return str_replace('Controllers', 'Forms', config('admin.route.namespace'));
     }
 

--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -39,7 +39,9 @@ class ImportCommand extends Command
         /** @phpstan-ignore-next-line */
         $className = Arr::get(Admin::$extensions, $extension);
 
+        // @phpstan-ignore-next-line $class is always string at runtime
         if (!class_exists($className) || !method_exists($className, 'import')) {
+            // @phpstan-ignore-next-line $className is always castable to string at runtime
             $this->error("Invalid Extension [$className]");
 
             return;

--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -31,10 +31,12 @@ class ImportCommand extends Command
     {
         $extension = $this->argument('extension');
 
+        /** @phpstan-ignore-next-line */
         if (empty($extension) || !Arr::has(Admin::$extensions, $extension)) {
             $extension = $this->choice('Please choose a extension to import', array_keys(Admin::$extensions));
         }
 
+        /** @phpstan-ignore-next-line */
         $className = Arr::get(Admin::$extensions, $extension);
 
         if (!class_exists($className) || !method_exists($className, 'import')) {

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -50,6 +50,7 @@ class InstallCommand extends Command
 
         $userModel = config('admin.database.users_model');
 
+        // @phpstan-ignore-next-line The value is always an object exposing count() at runtime
         if ($userModel::count() == 0) {
             $this->call('db:seed', ['--class' => \Encore\Admin\Auth\Database\AdminTablesSeeder::class]);
         }
@@ -62,9 +63,12 @@ class InstallCommand extends Command
      */
     protected function initAdminDirectory()
     {
+        // @phpstan-ignore-next-line Assigned value is always string at runtime
         $this->directory = config('admin.directory');
 
+        // @phpstan-ignore-next-line $filename is always string at runtime
         if (is_dir($this->directory)) {
+            // @phpstan-ignore-next-line $this->directory is always castable to string at runtime
             $this->line("<error>{$this->directory} directory already exists !</error> ");
 
             return;
@@ -96,6 +100,7 @@ class InstallCommand extends Command
         /** @phpstan-ignore-next-line */
         $this->laravel['files']->put(
             $homeController,
+            // @phpstan-ignore-next-line $replace is always array|string at runtime
             str_replace('DummyNamespace', config('admin.route.namespace'), $contents)
         );
         $this->line('<info>HomeController file was created:</info> '.str_replace(base_path(), '', $homeController));
@@ -114,6 +119,7 @@ class InstallCommand extends Command
         /** @phpstan-ignore-next-line */
         $this->laravel['files']->put(
             $authController,
+            // @phpstan-ignore-next-line $replace is always array|string at runtime
             str_replace('DummyNamespace', config('admin.route.namespace'), $contents)
         );
         $this->line('<info>AuthController file was created:</info> '.str_replace(base_path(), '', $authController));
@@ -132,6 +138,7 @@ class InstallCommand extends Command
         /** @phpstan-ignore-next-line */
         $this->laravel['files']->put(
             $exampleController,
+            // @phpstan-ignore-next-line $replace is always array|string at runtime
             str_replace('DummyNamespace', config('admin.route.namespace'), $contents)
         );
         $this->line('<info>ExampleController file was created:</info> '.str_replace(base_path(), '', $exampleController));

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -93,6 +93,7 @@ class InstallCommand extends Command
         $homeController = $this->directory.'/Controllers/HomeController.php';
         $contents = $this->getStub('HomeController');
 
+        /** @phpstan-ignore-next-line */
         $this->laravel['files']->put(
             $homeController,
             str_replace('DummyNamespace', config('admin.route.namespace'), $contents)
@@ -110,6 +111,7 @@ class InstallCommand extends Command
         $authController = $this->directory.'/Controllers/AuthController.php';
         $contents = $this->getStub('AuthController');
 
+        /** @phpstan-ignore-next-line */
         $this->laravel['files']->put(
             $authController,
             str_replace('DummyNamespace', config('admin.route.namespace'), $contents)
@@ -127,6 +129,7 @@ class InstallCommand extends Command
         $exampleController = $this->directory.'/Controllers/ExampleController.php';
         $contents = $this->getStub('ExampleController');
 
+        /** @phpstan-ignore-next-line */
         $this->laravel['files']->put(
             $exampleController,
             str_replace('DummyNamespace', config('admin.route.namespace'), $contents)
@@ -144,6 +147,7 @@ class InstallCommand extends Command
         $file = $this->directory.'/bootstrap.php';
 
         $contents = $this->getStub('bootstrap');
+        /** @phpstan-ignore-next-line */
         $this->laravel['files']->put($file, $contents);
         $this->line('<info>Bootstrap file was created:</info> '.str_replace(base_path(), '', $file));
     }
@@ -158,6 +162,7 @@ class InstallCommand extends Command
         $file = $this->directory.'/routes.php';
 
         $contents = $this->getStub('routes');
+        /** @phpstan-ignore-next-line */
         $this->laravel['files']->put($file, str_replace('DummyNamespace', config('admin.route.namespace'), $contents));
         $this->line('<info>Routes file was created:</info> '.str_replace(base_path(), '', $file));
     }
@@ -171,6 +176,7 @@ class InstallCommand extends Command
      */
     protected function getStub($name)
     {
+        /** @phpstan-ignore-next-line */
         return $this->laravel['files']->get(__DIR__."/stubs/$name.stub");
     }
 
@@ -183,6 +189,7 @@ class InstallCommand extends Command
      */
     protected function makeDir($path = '')
     {
+        /** @phpstan-ignore-next-line */
         $this->laravel['files']->makeDirectory("{$this->directory}/$path", 0755, true, true);
     }
 }

--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -185,6 +185,7 @@ class MakeCommand extends GeneratorCommand
             return $namespace;
         }
 
+        // @phpstan-ignore-next-line Return value is always string at runtime
         return config('admin.route.namespace');
     }
 

--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -45,6 +45,7 @@ class MakeCommand extends GeneratorCommand
 
         $stub = $this->option('stub');
 
+        /** @phpstan-ignore-next-line */
         if ($stub and !is_file($stub)) {
             $this->error('The stub file dose not exist.');
 
@@ -62,11 +63,13 @@ class MakeCommand extends GeneratorCommand
 
         if (parent::handle() !== false) {
             $name = $this->argument('name');
+            /** @phpstan-ignore-next-line */
             $path = Str::plural(Str::kebab(class_basename($this->option('model'))));
 
             $this->line('');
             $this->comment('Add the following route to app/Admin/routes.php:');
             $this->line('');
+            /** @phpstan-ignore-next-line */
             $this->info("    \$router->resource('{$path}', {$name}::class);");
             $this->line('');
         }
@@ -99,6 +102,7 @@ class MakeCommand extends GeneratorCommand
             return true;
         }
 
+        /** @phpstan-ignore-next-line */
         return class_exists($model) && is_subclass_of($model, Model::class);
     }
 
@@ -126,8 +130,9 @@ class MakeCommand extends GeneratorCommand
             [
                 $this->option('model'),
                 $this->option('title') ?: $this->option('model'),
+                /** @phpstan-ignore-next-line */
                 class_basename($this->option('model')),
-                $this->indentCodes($this->generator->generateGrid()),
+            $this->indentCodes($this->generator->generateGrid()),
                 $this->indentCodes($this->generator->generateShow()),
                 $this->indentCodes($this->generator->generateForm()),
             ],
@@ -155,6 +160,7 @@ class MakeCommand extends GeneratorCommand
     protected function getStub()
     {
         if ($stub = $this->option('stub')) {
+            /** @phpstan-ignore-next-line */
             return $stub;
         }
 
@@ -175,6 +181,7 @@ class MakeCommand extends GeneratorCommand
     protected function getDefaultNamespace($rootNamespace)
     {
         if ($namespace = $this->option('namespace')) {
+            /** @phpstan-ignore-next-line */
             return $namespace;
         }
 
@@ -188,6 +195,7 @@ class MakeCommand extends GeneratorCommand
      */
     protected function getNameInput()
     {
+        /** @phpstan-ignore-next-line */
         $name = trim($this->argument('name'));
 
         $this->type = $this->qualifyClass($name);

--- a/src/Console/MinifyCommand.php
+++ b/src/Console/MinifyCommand.php
@@ -123,6 +123,7 @@ class MinifyCommand extends Command
                 }
 
                 if (Str::contains($css, '?')) {
+                    /** @phpstan-ignore-next-line */
                     $css = substr($css, 0, strpos($css, '?'));
                 }
 
@@ -157,6 +158,7 @@ class MinifyCommand extends Command
                 }
 
                 if (Str::contains($js, '?')) {
+                    /** @phpstan-ignore-next-line */
                     $js = substr($js, 0, strpos($js, '?'));
                 }
 

--- a/src/Console/MinifyCommand.php
+++ b/src/Console/MinifyCommand.php
@@ -110,6 +110,7 @@ class MinifyCommand extends Command
         /** @phpstan-ignore-next-line  Unable to resolve the template type TValue in call to function collect  */
         $css = collect(array_merge(Admin::$css, Admin::baseCss()))
             ->unique()->map(function ($css) {
+                // @phpstan-ignore-next-line $path is always string at runtime
                 if (url()->isValidUrl($css)) {
                     $this->assets['css'][] = $css;
 
@@ -122,11 +123,13 @@ class MinifyCommand extends Command
                     return;
                 }
 
+                // @phpstan-ignore-next-line $haystack is always string at runtime
                 if (Str::contains($css, '?')) {
                     /** @phpstan-ignore-next-line */
                     $css = substr($css, 0, strpos($css, '?'));
                 }
 
+                // @phpstan-ignore-next-line $path is always string at runtime
                 return public_path($css);
             })->filter();
 
@@ -145,6 +148,7 @@ class MinifyCommand extends Command
         /** @phpstan-ignore-next-line  Unable to resolve the template type TValue in call to function collect  */
         $js = collect(array_merge(Admin::$js, Admin::baseJs()))
             ->unique()->map(function ($js) {
+                // @phpstan-ignore-next-line $path is always string at runtime
                 if (url()->isValidUrl($js)) {
                     $this->assets['js'][] = $js;
 
@@ -157,11 +161,13 @@ class MinifyCommand extends Command
                     return;
                 }
 
+                // @phpstan-ignore-next-line $haystack is always string at runtime
                 if (Str::contains($js, '?')) {
                     /** @phpstan-ignore-next-line */
                     $js = substr($js, 0, strpos($js, '?'));
                 }
 
+                // @phpstan-ignore-next-line $path is always string at runtime
                 return public_path($js);
             })->filter();
 

--- a/src/Console/ResetPasswordCommand.php
+++ b/src/Console/ResetPasswordCommand.php
@@ -28,6 +28,7 @@ class ResetPasswordCommand extends Command
     {
         $userModel = config('admin.database.users_model');
 
+        // @phpstan-ignore-next-line The value is always an object exposing all() at runtime
         $users = $userModel::all();
 
         askForUserName:
@@ -50,6 +51,7 @@ class ResetPasswordCommand extends Command
             goto enterPassword;
         }
 
+        // @phpstan-ignore-next-line $value is always string at runtime
         $user->password = bcrypt($password);
 
         $user->save();

--- a/src/Console/ResourceGenerator.php
+++ b/src/Console/ResourceGenerator.php
@@ -53,6 +53,7 @@ class ResourceGenerator
      */
     public function __construct($model)
     {
+        // @phpstan-ignore-next-line Assigned value is always Illuminate\Database\Eloquent\Model at runtime
         $this->model = $this->getModel($model);
     }
 
@@ -67,7 +68,9 @@ class ResourceGenerator
             return $model;
         }
 
+        // @phpstan-ignore-next-line $class is always string at runtime
         if (!class_exists($model) || !is_string($model) || !is_subclass_of($model, Model::class)) {
+            // @phpstan-ignore-next-line $model is always castable to string at runtime
             throw new \InvalidArgumentException("Invalid model [$model] !");
         }
 
@@ -112,6 +115,7 @@ class ResourceGenerator
                             break;
                         }
                     }
+                    // @phpstan-ignore-next-line $default is always castable to string at runtime
                     $defaultValue = "'{$default}'";
                     break;
                 case 'integer':
@@ -143,6 +147,7 @@ class ResourceGenerator
                     break;
                 default:
                     $fieldType = 'text';
+                    // @phpstan-ignore-next-line $default is always castable to string at runtime
                     $defaultValue = "'{$default}'";
             }
 
@@ -152,7 +157,9 @@ class ResourceGenerator
 
             $output .= sprintf($this->formats['form_field'], $fieldType, $name, $label);
 
+            // @phpstan-ignore-next-line $string is always string at runtime
             if (trim($defaultValue, "'\"")) {
+                // @phpstan-ignore-next-line $defaultValue is always castable to string at runtime
                 $output .= "->default({$defaultValue})";
             }
 

--- a/src/Console/ResourceGenerator.php
+++ b/src/Console/ResourceGenerator.php
@@ -208,6 +208,7 @@ class ResourceGenerator
      */
     protected function getReservedColumns()
     {
+        // @phpstan-ignore-next-line getCreatedAtColumn/getUpdatedAtColumn may return string|null but are always string in practice
         return [
             $this->model->getKeyName(),
             $this->model->getCreatedAtColumn(),

--- a/src/Console/UninstallCommand.php
+++ b/src/Console/UninstallCommand.php
@@ -43,8 +43,11 @@ class UninstallCommand extends Command
      */
     protected function removeFilesAndDirectories()
     {
+        /** @phpstan-ignore-next-line */
         $this->laravel['files']->deleteDirectory(config('admin.directory'));
+        /** @phpstan-ignore-next-line */
         $this->laravel['files']->deleteDirectory(public_path('vendor/laravel-admin/'));
+        /** @phpstan-ignore-next-line */
         $this->laravel['files']->delete(config_path('admin.php'));
     }
 }

--- a/src/Controllers/AdminController.php
+++ b/src/Controllers/AdminController.php
@@ -87,6 +87,7 @@ class AdminController extends Controller
         return $content
             ->title($this->title())
             ->description($this->description['edit'] ?? trans('admin.edit'))
+            // @phpstan-ignore-next-line The value is always an object exposing edit() at runtime
             ->body($this->form()->edit($id));
     }
 

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -104,6 +104,7 @@ class AuthController extends Controller
 
         return $content
             ->title(trans('admin.user_setting'))
+            // @phpstan-ignore-next-line User is guaranteed to be authenticated in admin routes
             ->body($form->edit(Admin::user()->id));
     }
 
@@ -114,6 +115,7 @@ class AuthController extends Controller
      */
     public function putSetting()
     {
+        // @phpstan-ignore-next-line User is guaranteed to be authenticated in admin routes
         return $this->settingForm()->update(Admin::user()->id);
     }
 
@@ -142,6 +144,7 @@ class AuthController extends Controller
         $form->ignore(['password_confirmation']);
 
         $form->saving(function (Form $form) {
+            // @phpstan-ignore-next-line Model is guaranteed to exist during saving callback
             if ($form->password && $form->model()->password != $form->password) {
                 $form->password = bcrypt($form->password);
             }

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -83,6 +83,7 @@ class AuthController extends Controller
 
         $request->session()->invalidate();
 
+        // @phpstan-ignore-next-line $to is always string|null at runtime
         return redirect(config('admin.route.prefix'));
     }
 

--- a/src/Controllers/Dashboard.php
+++ b/src/Controllers/Dashboard.php
@@ -108,6 +108,7 @@ class Dashboard
     {
         $json = file_get_contents(base_path('composer.json'));
 
+        /** @phpstan-ignore-next-line */
         $dependencies = json_decode($json, true)['require'];
 
         Admin::script("$('.dependencies').slimscroll({height:'510px',size:'3px'});");

--- a/src/Controllers/HandleController.php
+++ b/src/Controllers/HandleController.php
@@ -34,6 +34,7 @@ class HandleController extends Controller
         }
 
         if ($errors = $form->validate($request)) {
+            /** @phpstan-ignore-next-line */
             return back()->withInput()->withErrors($errors);
         }
 

--- a/src/Controllers/HandleController.php
+++ b/src/Controllers/HandleController.php
@@ -22,7 +22,9 @@ class HandleController extends Controller
 
         $formClass = $request->get('_form_');
 
+        // @phpstan-ignore-next-line $class is always string at runtime
         if (!class_exists($formClass)) {
+            // @phpstan-ignore-next-line $formClass is always castable to string at runtime
             throw new Exception("Form [{$formClass}] not exists.");
         }
 

--- a/src/Controllers/HasResourceActions.php
+++ b/src/Controllers/HasResourceActions.php
@@ -13,6 +13,7 @@ trait HasResourceActions
      */
     public function update($id)
     {
+        // @phpstan-ignore-next-line The value is always an object exposing update() at runtime (and 1 more mixed-type assumption on this line)
         return $this->form()->update($id);
     }
 
@@ -23,6 +24,7 @@ trait HasResourceActions
      */
     public function store()
     {
+        // @phpstan-ignore-next-line The value is always an object exposing store() at runtime
         return $this->form()->store();
     }
 
@@ -35,6 +37,7 @@ trait HasResourceActions
      */
     public function destroy($id)
     {
+        // @phpstan-ignore-next-line The value is always an object exposing destroy() at runtime (and 1 more mixed-type assumption on this line)
         return $this->form()->destroy($id);
     }
 }

--- a/src/Controllers/LogController.php
+++ b/src/Controllers/LogController.php
@@ -30,12 +30,14 @@ class LogController extends AdminController
         $grid->column('method')->display(function ($method) {
             $color = Arr::get(OperationLog::$methodColors, $method, 'grey');
 
+            // @phpstan-ignore-next-line $color is always castable to string at runtime
             return "<span class=\"badge bg-$color\">$method</span>";
         });
         $grid->column('path')->label('info');
         $grid->column('ip')->label('primary');
         $grid->column('input')->display(function ($input) {
             $input = json_decode($input, true);
+            // @phpstan-ignore-next-line $array is always array at runtime
             $input = Arr::except($input, ['_pjax', '_token', '_method', '_previous_']);
             if (empty($input)) {
                 return '<code>{}</code>';
@@ -56,6 +58,7 @@ class LogController extends AdminController
         $grid->filter(function (Grid\Filter $filter) {
             $userModel = config('admin.database.users_model');
 
+            // @phpstan-ignore-next-line The value is always an object exposing all() at runtime
             $filter->equal('user_id', 'User')->select($userModel::all()->pluck('name', 'id'));
             $filter->equal('method')->select(array_combine(OperationLog::$methods, OperationLog::$methods));
             $filter->like('path');

--- a/src/Controllers/MenuController.php
+++ b/src/Controllers/MenuController.php
@@ -43,6 +43,7 @@ class MenuController extends Controller
                     $form->icon('icon', trans('admin.icon'))->default('fa-bars')->rules('required')->help($this->iconHelp());
                     $form->text('uri', trans('admin.uri'));
                     $form->multipleSelect('roles', trans('admin.roles'))->options($roleModel::all()->pluck('name', 'id'));
+                    /** @phpstan-ignore-next-line */
                     if ((new $menuModel())->withPermission()) {
                         $form->select('permission', trans('admin.permission'))->options($permissionModel::pluck('name', 'slug'));
                     }

--- a/src/Controllers/MenuController.php
+++ b/src/Controllers/MenuController.php
@@ -38,13 +38,16 @@ class MenuController extends Controller
                     $permissionModel = config('admin.database.permissions_model');
                     $roleModel = config('admin.database.roles_model');
 
+                    // @phpstan-ignore-next-line The value is always an object exposing selectOptions() at runtime
                     $form->select('parent_id', trans('admin.parent_id'))->options($menuModel::selectOptions());
                     $form->text('title', trans('admin.title'))->rules('required');
                     $form->icon('icon', trans('admin.icon'))->default('fa-bars')->rules('required')->help($this->iconHelp());
                     $form->text('uri', trans('admin.uri'));
+                    // @phpstan-ignore-next-line The value is always an object exposing all() at runtime
                     $form->multipleSelect('roles', trans('admin.roles'))->options($roleModel::all()->pluck('name', 'id'));
                     /** @phpstan-ignore-next-line */
                     if ((new $menuModel())->withPermission()) {
+                        // @phpstan-ignore-next-line The value is always an object exposing pluck() at runtime
                         $form->select('permission', trans('admin.permission'))->options($permissionModel::pluck('name', 'slug'));
                     }
                     $form->hidden('_token')->default(csrf_token());
@@ -73,6 +76,7 @@ class MenuController extends Controller
     {
         $menuModel = config('admin.database.menu_model');
 
+        // @phpstan-ignore-next-line The value is always an object exposing tree() at runtime
         return $menuModel::tree(function (Tree $tree) {
             $tree->disableCreate();
 
@@ -127,14 +131,17 @@ class MenuController extends Controller
 
         $form->display('id', 'ID');
 
+        // @phpstan-ignore-next-line The value is always an object exposing selectOptions() at runtime
         $form->select('parent_id', trans('admin.parent_id'))->options($menuModel::selectOptions());
         $form->text('title', trans('admin.title'))->rules('required');
         $form->icon('icon', trans('admin.icon'))->default('fa-bars')->rules('required')->help($this->iconHelp());
         $form->text('uri', trans('admin.uri'));
+        // @phpstan-ignore-next-line The value is always an object exposing all() at runtime
         $form->multipleSelect('roles', trans('admin.roles'))->options($roleModel::all()->pluck('name', 'id'));
         /** @var Menu $menu */
         $menu = $form->model();
         if ($menu->withPermission()) {
+            // @phpstan-ignore-next-line The value is always an object exposing pluck() at runtime
             $form->select('permission', trans('admin.permission'))->options($permissionModel::pluck('name', 'slug'));
         }
 

--- a/src/Controllers/PermissionController.php
+++ b/src/Controllers/PermissionController.php
@@ -47,12 +47,14 @@ class PermissionController extends AdminController
                 }
                 /** @phpstan-ignore-next-line Unable to resolve the template type TKey in call to function collect */
                 $method = collect($method)->map(function ($name) {
+                    // @phpstan-ignore-next-line $string is always string at runtime
                     return strtoupper($name);
                 })->map(function ($name) {
                     return "<span class='label label-primary'>{$name}</span>";
                 })->implode('&nbsp;');
 
                 if (!empty(config('admin.route.prefix'))) {
+                    // @phpstan-ignore-next-line $string is always string at runtime
                     $path = '/'.trim(config('admin.route.prefix'), '/').$path;
                 }
 
@@ -83,6 +85,7 @@ class PermissionController extends AdminController
     {
         $permissionModel = config('admin.database.permissions_model');
 
+        // @phpstan-ignore-next-line The value is always an object exposing findOrFail() at runtime
         $show = new Show($permissionModel::findOrFail($id));
 
         $show->field('id', 'ID');
@@ -100,12 +103,14 @@ class PermissionController extends AdminController
 
                 /** @phpstan-ignore-next-line Unable to resolve the template type TKey in call to function collect */
                 $method = collect($method)->map(function ($name) {
+                    // @phpstan-ignore-next-line $string is always string at runtime
                     return strtoupper($name);
                 })->map(function ($name) {
                     return "<span class='label label-primary'>{$name}</span>";
                 })->implode('&nbsp;');
 
                 if (!empty(config('admin.route.prefix'))) {
+                    // @phpstan-ignore-next-line $string is always string at runtime
                     $path = '/'.trim(config('admin.route.prefix'), '/').$path;
                 }
 
@@ -135,6 +140,7 @@ class PermissionController extends AdminController
         $form->text('slug', trans('admin.slug'))->rules('required');
         $form->text('name', trans('admin.name'))->rules('required');
 
+        // @phpstan-ignore-next-line The value is always an object exposing help() at runtime
         $form->multipleSelect('http_method', trans('admin.http.method'))
             ->options($this->getHttpMethodsOptions())
             ->help(trans('admin.all_methods_if_empty'));
@@ -155,6 +161,7 @@ class PermissionController extends AdminController
     {
         $model = config('admin.database.permissions_model');
 
+        // @phpstan-ignore-next-line The value is always a class exposing $httpMethods at runtime (and 1 more mixed-type assumption on this line)
         return array_combine($model::$httpMethods, $model::$httpMethods);
     }
 }

--- a/src/Controllers/PermissionController.php
+++ b/src/Controllers/PermissionController.php
@@ -30,6 +30,7 @@ class PermissionController extends AdminController
     {
         $permissionModel = config('admin.database.permissions_model');
 
+        /** @phpstan-ignore-next-line */
         $grid = new Grid(new $permissionModel());
 
         $grid->column('id', 'ID')->sortable();

--- a/src/Controllers/RoleController.php
+++ b/src/Controllers/RoleController.php
@@ -25,6 +25,7 @@ class RoleController extends AdminController
     {
         $roleModel = config('admin.database.roles_model');
 
+        /** @phpstan-ignore-next-line */
         $grid = new Grid(new $roleModel());
 
         $grid->column('id', 'ID')->sortable();

--- a/src/Controllers/RoleController.php
+++ b/src/Controllers/RoleController.php
@@ -38,6 +38,7 @@ class RoleController extends AdminController
         $grid->column('updated_at', trans('admin.updated_at'));
 
         $grid->actions(function (Grid\Displayers\Actions $actions) {
+            // @phpstan-ignore-next-line The value is always an object exposing $slug at runtime
             if ($actions->row->slug == 'administrator') {
                 $actions->disableDelete();
             }
@@ -63,6 +64,7 @@ class RoleController extends AdminController
     {
         $roleModel = config('admin.database.roles_model');
 
+        // @phpstan-ignore-next-line The value is always an object exposing findOrFail() at runtime
         $show = new Show($roleModel::findOrFail($id));
 
         $show->field('id', 'ID');
@@ -93,6 +95,7 @@ class RoleController extends AdminController
 
         $form->text('slug', trans('admin.slug'))->rules('required');
         $form->text('name', trans('admin.name'))->rules('required');
+        // @phpstan-ignore-next-line The value is always an object exposing all() at runtime
         $form->listbox('permissions', trans('admin.permissions'))->options($permissionModel::all()->pluck('name', 'id'));
 
         $form->display('created_at', trans('admin.created_at'));

--- a/src/Controllers/UserController.php
+++ b/src/Controllers/UserController.php
@@ -25,6 +25,7 @@ class UserController extends AdminController
     {
         $userModel = config('admin.database.users_model');
 
+        /** @phpstan-ignore-next-line */
         $grid = new Grid(new $userModel());
 
         $grid->column('id', 'ID')->sortable();

--- a/src/Controllers/UserController.php
+++ b/src/Controllers/UserController.php
@@ -61,6 +61,7 @@ class UserController extends AdminController
     {
         $userModel = config('admin.database.users_model');
 
+        // @phpstan-ignore-next-line The value is always an object exposing findOrFail() at runtime
         $show = new Show($userModel::findOrFail($id));
 
         $show->field('id', 'ID');
@@ -95,7 +96,9 @@ class UserController extends AdminController
 
         $form->display('id', 'ID');
         $form->text('username', trans('admin.username'))
+            // @phpstan-ignore-next-line $userTable is always castable to string at runtime
             ->creationRules(['required', "unique:{$userTable}"])
+            // @phpstan-ignore-next-line $userTable is always castable to string at runtime
             ->updateRules(['required', "unique:{$userTable},username,{{id}}"]);
 
         $form->text('name', trans('admin.name'))->rules('required');
@@ -108,7 +111,9 @@ class UserController extends AdminController
 
         $form->ignore(['password_confirmation']);
 
+        // @phpstan-ignore-next-line The value is always an object exposing all() at runtime
         $form->multipleSelect('roles', trans('admin.roles'))->options($roleModel::all()->pluck('name', 'id'));
+        // @phpstan-ignore-next-line The value is always an object exposing all() at runtime
         $form->multipleSelect('permissions', trans('admin.permissions'))->options($permissionModel::all()->pluck('name', 'id'));
 
         $form->display('created_at', trans('admin.created_at'));

--- a/src/Controllers/UserController.php
+++ b/src/Controllers/UserController.php
@@ -115,6 +115,7 @@ class UserController extends AdminController
         $form->display('updated_at', trans('admin.updated_at'));
 
         $form->saving(function (Form $form) {
+            // @phpstan-ignore-next-line Model is guaranteed to exist during saving callback
             if ($form->password && $form->model()->password != $form->password) {
                 $form->password = bcrypt($form->password);
             }

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -94,6 +94,7 @@ abstract class Extension
             self::$instance[$class] = new static();
         }
 
+        /** @phpstan-ignore-next-line */
         return static::$instance[$class];
     }
 
@@ -222,8 +223,10 @@ abstract class Extension
         $name = array_search(get_called_class(), Admin::$extensions);
 
         if (is_null($key)) {
+            /** @phpstan-ignore-next-line */
             $key = sprintf('admin.extensions.%s', strtolower($name));
         } else {
+            /** @phpstan-ignore-next-line */
             $key = sprintf('admin.extensions.%s.%s', strtolower($name), $key);
         }
 

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -324,8 +324,10 @@ abstract class Extension
     {
         $menuModel = config('admin.database.menu_model');
 
+        // @phpstan-ignore-next-line The value is always an object exposing max() at runtime
         $lastOrder = $menuModel::max('order');
 
+        // @phpstan-ignore-next-line The value is always an object exposing create() at runtime
         $menuModel::create([
             'parent_id' => $parentId,
             'order'     => $lastOrder + 1,
@@ -348,9 +350,11 @@ abstract class Extension
     {
         $permissionModel = config('admin.database.permissions_model');
 
+        // @phpstan-ignore-next-line The value is always an object exposing create() at runtime
         $permissionModel::create([
             'name'      => $name,
             'slug'      => $slug,
+            // @phpstan-ignore-next-line $string is always string at runtime
             'http_path' => '/'.trim($path, '/'),
         ]);
     }
@@ -369,9 +373,11 @@ abstract class Extension
                 'prefix'     => config('admin.route.prefix'),
                 'middleware' => config('admin.route.middleware'),
             ],
+            // @phpstan-ignore-next-line $arrays is always array at runtime
             static::config('route', [])
         );
 
+        // @phpstan-ignore-next-line $routes is always array|Closure|string at runtime
         Route::group($attributes, $callback);
     }
 }

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -89,6 +89,7 @@ abstract class Extension
     {
         $class = get_called_class();
 
+        /** @phpstan-ignore-next-line Cannot access offset class-string<static(Encore\\Admin\\Extension)> on Encore\\Admin\\Extension. */
         if (!isset(self::$instance[$class]) || !self::$instance[$class] instanceof $class) {
             /** @phpstan-ignore-next-line https://phpstan.org/blog/solving-phpstan-error-unsafe-usage-of-new-static */
             self::$instance[$class] = new static();

--- a/src/Form.php
+++ b/src/Form.php
@@ -246,6 +246,7 @@ class Form implements Renderable
      */
     public static function init(Closure $callback = null)
     {
+        // @phpstan-ignore-next-line Callback may be null but is handled during execution
         static::$initCallbacks[] = $callback;
     }
 
@@ -386,6 +387,7 @@ class Form implements Renderable
 
             collect(explode(',', $id))->filter()->each(function ($id) {
                 /** @var SoftDeletableModel $builder */
+                // @phpstan-ignore-next-line Model is guaranteed to be set when destroy is called
                 $builder = $this->model()->newQuery();
 
                 if ($this->isSoftDeletes) {
@@ -479,9 +481,11 @@ class Form implements Renderable
             $inserts = $this->prepareInsert($this->updates);
 
             foreach ($inserts as $column => $value) {
+                // @phpstan-ignore-next-line Model is guaranteed to be set during store
                 $this->model->setAttribute($column, $value);
             }
 
+            // @phpstan-ignore-next-line Model is guaranteed to be set during store
             $this->model->save();
             $this->storeJancode($this->model);
 
@@ -611,6 +615,7 @@ class Form implements Renderable
         $relations = [];
 
         foreach ($inputs as $column => $value) {
+            // @phpstan-ignore-next-line Model is guaranteed to be set at this point
             if (!method_exists($this->model, $column)) {
                 continue;
             }
@@ -679,9 +684,11 @@ class Form implements Renderable
 
             foreach ($updates as $column => $value) {
                 /* @var Model $this->model */
+                // @phpstan-ignore-next-line Model is guaranteed to be set during update
                 $this->model->setAttribute($column, $value);
             }
 
+            // @phpstan-ignore-next-line Model is guaranteed to be set during update
             $this->model->save();
 
             $this->updateRelation($this->relations);
@@ -788,9 +795,11 @@ class Form implements Renderable
 
             foreach ($updates as $column => $value) {
                 /* @var Model $this->model */
+                // @phpstan-ignore-next-line Model is guaranteed to be set during validationUpdate
                 $this->model->setAttribute($column, $value);
             }
 
+            // @phpstan-ignore-next-line Model is guaranteed to be set during validationUpdate
             $this->model->save();
 
             $this->updateRelation($this->relations);
@@ -871,6 +880,7 @@ class Form implements Renderable
     {
         $resourcesPath = $this->getResource(0);
 
+        // @phpstan-ignore-next-line Model is guaranteed to be set after store
         $key = $this->model->getKey();
 
         return $this->redirectAfterSaving($resourcesPath, $key);
@@ -1030,6 +1040,7 @@ class Form implements Renderable
     {
         if (array_key_exists('_orderable', $input)) {
             /** @var SortableModel $model */
+            // @phpstan-ignore-next-line Model is guaranteed to be set at this point
             $model = $this->model->find($id);
 
             if ($model instanceof Sortable) {
@@ -1052,6 +1063,7 @@ class Form implements Renderable
     protected function updateRelation($relationsData)
     {
         foreach ($relationsData as $name => $values) {
+            // @phpstan-ignore-next-line Model is guaranteed to be set when updating relations
             if (!method_exists($this->model, $name)) {
                 continue;
             }
@@ -1114,6 +1126,7 @@ class Form implements Renderable
                     if (!$this->model->{$relation->{$foreignKeyMethod}()}) {
                         $this->model->{$relation->{$foreignKeyMethod}()} = $parent->getKey();
 
+                        // @phpstan-ignore-next-line Model is guaranteed to be set when saving relations
                         $this->model->save();
                     }
 
@@ -1394,6 +1407,7 @@ class Form implements Renderable
     {
 //        static::doNotSnakeAttributes($this->model);
 
+        // @phpstan-ignore-next-line Model is guaranteed to be set when setting field original values
         $values = $this->model->toArray();
 
         $this->builder->fields()->each(function (Field $field) use ($values) {
@@ -1470,12 +1484,14 @@ class Form implements Renderable
         }
 
         foreach ($inserts as $column => $value) {
+            // @phpstan-ignore-next-line Model is guaranteed to be set at this point
             $this->model->setAttribute($column, $value);
         }
 
         // Now, I only call this function, If need, set such as array.
         $this->getRelationModelByInputs($data);
 
+        // @phpstan-ignore-next-line Model may be null but is expected to be set here
         return $this->model;
     }
 
@@ -1497,7 +1513,7 @@ class Form implements Renderable
 
         $relations = [];
         foreach ($inputs as $column => $value) {
-            
+            // @phpstan-ignore-next-line Model is guaranteed to be set at this point
             if (!method_exists($this->model, $column)) {
                 continue;
             }
@@ -1656,6 +1672,7 @@ class Form implements Renderable
             $func($input, $message, $this);
         }
         // if contains function 'validatorSaving' in model, call
+        // @phpstan-ignore-next-line Model is guaranteed to be set during validation
         if(method_exists($this->model, 'validatorSaving')){
             if(is_array($validateResult = $this->model->validatorSaving($input))){
                 $message = $message->merge($validateResult);
@@ -1702,11 +1719,13 @@ class Form implements Renderable
             if (Str::contains($column, '.')) {
                 list($relation) = explode('.', $column);
 
+                // @phpstan-ignore-next-line Model is guaranteed to be set at this point
                 if (method_exists($this->model, $relation) &&
                     $this->model->$relation() instanceof Relations\Relation
                 ) {
                     $relations[] = $relation;
                 }
+            // @phpstan-ignore-next-line Model is guaranteed to be set at this point
             } elseif (method_exists($this->model, $column) &&
                 !method_exists(Model::class, $column)
             ) {
@@ -1830,6 +1849,7 @@ class Form implements Renderable
             return $this->builder->getTools();
         }
 
+        // @phpstan-ignore-next-line Closure is guaranteed to be set when called with arguments
         $callback->call($this, $this->builder->getTools());
     }
 
@@ -2002,6 +2022,7 @@ class Form implements Renderable
             return $this->builder()->getFooter();
         }
 
+        // @phpstan-ignore-next-line Closure is guaranteed to be set when called with arguments
         call_user_func($callback, $this->builder()->getFooter());
     }
 

--- a/src/Form.php
+++ b/src/Form.php
@@ -466,13 +466,11 @@ class Form implements Renderable
         }
 
         // Handle validation errors.
-        /** @phpstan-ignore-next-line */
         if ($validationMessages = $this->validationMessages($data)) {
-            /** @phpstan-ignore-next-line */
+            /** @phpstan-ignore-next-line Parameter $provider of method withErrors() expects array|Illuminate\Contracts\Support\MessageProvider|string, Illuminate\Support\MessageBag|false given. */
             return back()->withInput()->withErrors($validationMessages);
         }
 
-        /** @phpstan-ignore-next-line */
         if (($response = $this->prepare($data)) instanceof Response) {
             return $response;
         }
@@ -867,7 +865,7 @@ class Form implements Renderable
     /**
      * Get RedirectResponse after store.
      *
-     * @return \Illuminate\Http\RedirectResponse
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector
      */
     public function redirectAfterStore()
     {
@@ -883,7 +881,7 @@ class Form implements Renderable
      *
      * @param mixed $key
      *
-     * @return \Illuminate\Http\RedirectResponse
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector
      */
     protected function redirectAfterUpdate($key)
     {
@@ -907,6 +905,7 @@ class Form implements Renderable
         admin_toastr(trans('admin.save_succeeded'));
         
         if(isset($redirect)){
+            /** @phpstan-ignore-next-line Method redirectAfterSaving() should return Illuminate\\Http\\RedirectResponse|Illuminate\\Routing\\Redirector but returns Illuminate\\Http\\RedirectResponse|Illuminate\\Routing\\Redirector|null. */
             return $redirect;
         }
 
@@ -1057,7 +1056,6 @@ class Form implements Renderable
                 continue;
             }
 
-            /** @phpstan-ignore-next-line */
             $relation = $this->model->$name();
 
             $oneToOneRelation = $relation instanceof Relations\HasOne
@@ -1079,7 +1077,6 @@ class Form implements Renderable
                     break;
                 case $relation instanceof Relations\HasOne:
 
-                    /** @phpstan-ignore-next-line */
                     $related = $this->model->$name;
 
                     // if related is empty
@@ -1087,7 +1084,6 @@ class Form implements Renderable
                         $related = $relation->getRelated();
                         $qualifiedParentKeyName = $relation->getQualifiedParentKeyName();
                         $localKey = Arr::last(explode('.', $qualifiedParentKeyName));
-                        /** @phpstan-ignore-next-line */
                         $related->{$relation->getForeignKeyName()} = $this->model->{$localKey};
                     }
 
@@ -1100,7 +1096,6 @@ class Form implements Renderable
                 case $relation instanceof Relations\BelongsTo:
                 case $relation instanceof Relations\MorphTo:
 
-                    /** @phpstan-ignore-next-line */
                     $parent = $this->model->$name;
 
                     // if related is empty
@@ -1116,9 +1111,7 @@ class Form implements Renderable
 
                     // When in creating, associate two models
                     $foreignKeyMethod = version_compare(app()->version(), '5.8.0', '<') ? 'getForeignKey' : 'getForeignKeyName';
-                    /** @phpstan-ignore-next-line */
                     if (!$this->model->{$relation->{$foreignKeyMethod}()}) {
-                        /** @phpstan-ignore-next-line */
                         $this->model->{$relation->{$foreignKeyMethod}()} = $parent->getKey();
 
                         $this->model->save();
@@ -1126,7 +1119,6 @@ class Form implements Renderable
 
                     break;
                 case $relation instanceof Relations\MorphOne:
-                    /** @phpstan-ignore-next-line */
                     $related = $this->model->$name;
                     if (is_null($related)) {
                         $related = $relation->make();
@@ -1143,11 +1135,13 @@ class Form implements Renderable
                         /** @var Relations\Relation<Model>|\Illuminate\Database\Eloquent\Builder<Model> $relation */
                         $relation = $this->model()->$name();
 
+                        /** @phpstan-ignore-next-line Call to an undefined method getRelated(). */
                         $keyName = $relation->getRelated()->getKeyName();
 
                         $instance = $relation->findOrNew(Arr::get($related, $keyName));
 
                         if ($related[static::REMOVE_FLAG_NAME] == 1) {
+                            /** @phpstan-ignore-next-line Call to an undefined method delete(). */
                             $instance->delete();
 
                             continue;
@@ -1155,8 +1149,10 @@ class Form implements Renderable
 
                         Arr::forget($related, static::REMOVE_FLAG_NAME);
 
+                        /** @phpstan-ignore-next-line Call to an undefined method fill(). */
                         $instance->fill($related);
 
+                        /** @phpstan-ignore-next-line Call to an undefined method save(). */
                         $instance->save();
                     }
 
@@ -1428,6 +1424,7 @@ class Form implements Renderable
         if($id instanceof \Illuminate\Database\Eloquent\Model){
             $this->model = $id;
         }else{
+            /** @phpstan-ignore-next-line Property Encore\Admin\Form::$model (Illuminate\Database\Eloquent\Model|null) does not accept Encore\Admin\SoftDeletableModel|Illuminate\Database\Eloquent\Collection<int, Encore\Admin\SoftDeletableModel>|Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model. */
             $this->model = $builder->with($relations)->findOrFail($id);
         }
 
@@ -1462,7 +1459,6 @@ class Form implements Renderable
             $data = request()->all();
         }
 
-        /** @phpstan-ignore-next-line */
         if (($response = $this->prepare($data)) instanceof Response) {
             return $response;
         }
@@ -1506,6 +1502,7 @@ class Form implements Renderable
                 continue;
             }
 
+            /** @phpstan-ignore-next-line Parameter $callback of function call_user_func expects callable, array{Illuminate\\Database\\Eloquent\\Model, string} given. */
             $relation = call_user_func([$this->model, $column]);
 
             if (!($relation instanceof Relations\Relation)) {
@@ -1623,6 +1620,7 @@ class Form implements Renderable
     {
         $message = $this->validationMessages($input);
         if($message !== false){
+            /** @phpstan-ignore-next-line Parameter $provider of method withErrors() expects array|Illuminate\\Contracts\\Support\\MessageProvider|string, Illuminate\\Support\\MessageBag|false given. */
             return back()->withInput()->withErrors($message);
         }
         return true;
@@ -2208,6 +2206,7 @@ class Form implements Renderable
                 continue;
             }
 
+            /** @phpstan-ignore-next-line Parameter $callback of function call_user_func expects callable, array{class-string, string} given. */
             $assets = call_user_func([$field, 'getAssets']);
 
             $css->push(Arr::get($assets, 'css'));
@@ -2257,11 +2256,12 @@ class Form implements Renderable
         if ($className = static::findFieldClass($method)) {
             $column = Arr::get($arguments, 0, ''); //[0];
 
-            /** @phpstan-ignore-next-line */
             $element = new $className($column, array_slice($arguments, 1));
 
+            /** @phpstan-ignore-next-line Parameter $field of method pushField() expects Encore\\Admin\\Form\\Field, object given. */
             $this->pushField($element);
 
+            /** @phpstan-ignore-next-line Method __call() should return Encore\\Admin\\Form\\Field but returns object. */
             return $element;
         }
 

--- a/src/Form.php
+++ b/src/Form.php
@@ -394,13 +394,16 @@ class Form implements Renderable
 
                 $model = $builder->with($this->getRelations())->findOrFail($id);
 
+                /** @phpstan-ignore-next-line */
                 if (($this->isSoftDeletes && $model->trashed()) || $this->isForceDelete) {
+                    /** @phpstan-ignore-next-line */
                     $this->deleteFiles($model, true);
                     $model->forceDelete();
 
                     return;
                 }
 
+                /** @phpstan-ignore-next-line */
                 $this->deleteFiles($model);
                 $model->delete();
             });
@@ -463,10 +466,13 @@ class Form implements Renderable
         }
 
         // Handle validation errors.
+        /** @phpstan-ignore-next-line */
         if ($validationMessages = $this->validationMessages($data)) {
+            /** @phpstan-ignore-next-line */
             return back()->withInput()->withErrors($validationMessages);
         }
 
+        /** @phpstan-ignore-next-line */
         if (($response = $this->prepare($data)) instanceof Response) {
             return $response;
         }
@@ -611,6 +617,7 @@ class Form implements Renderable
                 continue;
             }
 
+            /** @phpstan-ignore-next-line */
             $relation = call_user_func([$this->model, $column]);
 
             if ($relation instanceof Relations\Relation) {
@@ -647,19 +654,24 @@ class Form implements Renderable
             $builder = $builder->withTrashed();
         }
 
+        /** @phpstan-ignore-next-line */
         $this->model = $builder->with($this->getRelations())->findOrFail($id);
 
         $this->setFieldOriginalValue();
 
         // Handle validation errors.
+        /** @phpstan-ignore-next-line */
         if ($validationMessages = $this->validationMessages($data)) {
             if (!$isEditable) {
+                /** @phpstan-ignore-next-line */
                 return back()->withInput()->withErrors($validationMessages);
             }
 
+            /** @phpstan-ignore-next-line */
             return response()->json(['errors' => Arr::dot($validationMessages->getMessages())], 422);
         }
 
+        /** @phpstan-ignore-next-line */
         if (($response = $this->prepare($data)) instanceof Response) {
             return $response;
         }
@@ -751,19 +763,24 @@ class Form implements Renderable
             $builder = $builder->withTrashed();
         }
 
+        /** @phpstan-ignore-next-line */
         $this->model = $builder->with($this->getRelations())->findOrFail($id);
 
         $this->setFieldOriginalValue();
 
         // Handle validation errors.
+        /** @phpstan-ignore-next-line */
         if ($validationMessages = $this->validationMessages($data)) {
             if (!$isEditable) {
+                /** @phpstan-ignore-next-line */
                 return back()->withInput()->withErrors($validationMessages);
             }
 
+            /** @phpstan-ignore-next-line */
             return response()->json(['errors' => Arr::dot($validationMessages->getMessages())], 422);
         }
 
+        /** @phpstan-ignore-next-line */
         if (($response = $this->prepare($data)) instanceof Response) {
             return $response;
         }
@@ -826,11 +843,13 @@ class Form implements Renderable
             $builder = $builder->withTrashed();
         }
 
+        /** @phpstan-ignore-next-line */
         $this->model = $builder->with($this->getRelations())->findOrFail($id);
 
         $this->setFieldOriginalValue();
 
         // Handle validation errors.
+        /** @phpstan-ignore-next-line */
         if ($validationMessages = $this->validationMessages($data)) {
             return [
                 'validationMessages' => $validationMessages,
@@ -1038,6 +1057,7 @@ class Form implements Renderable
                 continue;
             }
 
+            /** @phpstan-ignore-next-line */
             $relation = $this->model->$name();
 
             $oneToOneRelation = $relation instanceof Relations\HasOne
@@ -1059,6 +1079,7 @@ class Form implements Renderable
                     break;
                 case $relation instanceof Relations\HasOne:
 
+                    /** @phpstan-ignore-next-line */
                     $related = $this->model->$name;
 
                     // if related is empty
@@ -1066,6 +1087,7 @@ class Form implements Renderable
                         $related = $relation->getRelated();
                         $qualifiedParentKeyName = $relation->getQualifiedParentKeyName();
                         $localKey = Arr::last(explode('.', $qualifiedParentKeyName));
+                        /** @phpstan-ignore-next-line */
                         $related->{$relation->getForeignKeyName()} = $this->model->{$localKey};
                     }
 
@@ -1078,6 +1100,7 @@ class Form implements Renderable
                 case $relation instanceof Relations\BelongsTo:
                 case $relation instanceof Relations\MorphTo:
 
+                    /** @phpstan-ignore-next-line */
                     $parent = $this->model->$name;
 
                     // if related is empty
@@ -1093,7 +1116,9 @@ class Form implements Renderable
 
                     // When in creating, associate two models
                     $foreignKeyMethod = version_compare(app()->version(), '5.8.0', '<') ? 'getForeignKey' : 'getForeignKeyName';
+                    /** @phpstan-ignore-next-line */
                     if (!$this->model->{$relation->{$foreignKeyMethod}()}) {
+                        /** @phpstan-ignore-next-line */
                         $this->model->{$relation->{$foreignKeyMethod}()} = $parent->getKey();
 
                         $this->model->save();
@@ -1101,6 +1126,7 @@ class Form implements Renderable
 
                     break;
                 case $relation instanceof Relations\MorphOne:
+                    /** @phpstan-ignore-next-line */
                     $related = $this->model->$name;
                     if (is_null($related)) {
                         $related = $relation->make();
@@ -1436,6 +1462,7 @@ class Form implements Renderable
             $data = request()->all();
         }
 
+        /** @phpstan-ignore-next-line */
         if (($response = $this->prepare($data)) instanceof Response) {
             return $response;
         }
@@ -2230,6 +2257,7 @@ class Form implements Renderable
         if ($className = static::findFieldClass($method)) {
             $column = Arr::get($arguments, 0, ''); //[0];
 
+            /** @phpstan-ignore-next-line */
             $element = new $className($column, array_slice($arguments, 1));
 
             $this->pushField($element);

--- a/src/Form.php
+++ b/src/Form.php
@@ -224,6 +224,7 @@ class Form implements Renderable
      */
     public function __construct($model, Closure $callback = null)
     {
+        // @phpstan-ignore-next-line Assigned value is always Illuminate\Database\Eloquent\Model|null at runtime
         $this->model = $model;
 
         $this->builder = new Builder($this);
@@ -232,6 +233,7 @@ class Form implements Renderable
             $callback($this);
         }
 
+        // @phpstan-ignore-next-line $class is always object|string at runtime
         $this->isSoftDeletes = in_array(SoftDeletes::class, class_uses_deep($this->model));
 
         $this->callInitCallbacks();
@@ -294,6 +296,7 @@ class Form implements Renderable
      */
     public function setModel($model)
     {
+        // @phpstan-ignore-next-line Assigned value is always Illuminate\Database\Eloquent\Model|null at runtime
         $this->model = $model;
         return $this;
     }
@@ -385,6 +388,7 @@ class Form implements Renderable
                 return $ret;
             }
 
+            // @phpstan-ignore-next-line $string is always string at runtime
             collect(explode(',', $id))->filter()->each(function ($id) {
                 /** @var SoftDeletableModel $builder */
                 // @phpstan-ignore-next-line Model is guaranteed to be set when destroy is called
@@ -468,11 +472,13 @@ class Form implements Renderable
         }
 
         // Handle validation errors.
+        // @phpstan-ignore-next-line $input is always array at runtime
         if ($validationMessages = $this->validationMessages($data)) {
             /** @phpstan-ignore-next-line Parameter $provider of method withErrors() expects array|Illuminate\Contracts\Support\MessageProvider|string, Illuminate\Support\MessageBag|false given. */
             return back()->withInput()->withErrors($validationMessages);
         }
 
+        // @phpstan-ignore-next-line $data is always array at runtime
         if (($response = $this->prepare($data)) instanceof Response) {
             return $response;
         }
@@ -528,6 +534,7 @@ class Form implements Renderable
             DB::table('jan_codes')
                 ->insert([
                     'table_id' => $table_code,
+                    // @phpstan-ignore-next-line The value is always an object exposing $id at runtime
                     'target_id' => $model->id,
                     'jan_code' => $jan_code,
                     'created_at' => now(),
@@ -644,8 +651,10 @@ class Form implements Renderable
         $formId = request()->get('formid');
         $data = ($data) ?: request()->all();
 
+        // @phpstan-ignore-next-line $input is always array at runtime
         $isEditable = $this->isEditable($data);
 
+        // @phpstan-ignore-next-line $data is always array at runtime
         if (($data = $this->handleColumnUpdates($id, $data)) instanceof Response) {
             return $data;
         }
@@ -755,8 +764,10 @@ class Form implements Renderable
     {
         $data = ($data) ?: request()->all();
 
+        // @phpstan-ignore-next-line $input is always array at runtime
         $isEditable = $this->isEditable($data);
 
+        // @phpstan-ignore-next-line $data is always array at runtime
         if (($data = $this->handleColumnUpdates($id, $data)) instanceof Response) {
             return $data;
         }
@@ -837,8 +848,10 @@ class Form implements Renderable
     {
         $data = ($data) ?: request()->all();
 
+        // @phpstan-ignore-next-line $input is always array at runtime
         $isEditable = $this->isEditable($data);
 
+        // @phpstan-ignore-next-line $data is always array at runtime
         if (($data = $this->handleColumnUpdates($id, $data)) instanceof Response) {
             return $data;
         }
@@ -883,6 +896,7 @@ class Form implements Renderable
         // @phpstan-ignore-next-line Model is guaranteed to be set after store
         $key = $this->model->getKey();
 
+        // @phpstan-ignore-next-line $key is always string at runtime
         return $this->redirectAfterSaving($resourcesPath, $key);
     }
 
@@ -897,6 +911,7 @@ class Form implements Renderable
     {
         $resourcesPath = $this->getResource(-1);
 
+        // @phpstan-ignore-next-line $key is always string at runtime
         return $this->redirectAfterSaving($resourcesPath, $key);
     }
 
@@ -910,6 +925,7 @@ class Form implements Renderable
      */
     protected function redirectAfterSaving($resourcesPath, $key)
     {
+        // @phpstan-ignore-next-line $afterSaveValue is always int at runtime
         $redirect = $this->builder()->getFooter()->getRedirect($resourcesPath, $key, request('after-save'));
 
         admin_toastr(trans('admin.save_succeeded'));
@@ -924,6 +940,7 @@ class Form implements Renderable
         } else {
             $url = request(Builder::PREVIOUS_URL_KEY) ?: $resourcesPath;
         }
+        // @phpstan-ignore-next-line $to is always string|null at runtime
         return redirect($url);
     }
 
@@ -1084,6 +1101,7 @@ class Form implements Renderable
                 case $relation instanceof Relations\BelongsToMany:
                 case $relation instanceof Relations\MorphToMany:
                     if (isset($prepared[$name])) {
+                        // @phpstan-ignore-next-line $ids is always array|Illuminate\Database\Eloquent\Model|Illuminate\Support\Collection at runtime
                         $relation->sync($prepared[$name]);
                     }
                     break;
@@ -1099,6 +1117,7 @@ class Form implements Renderable
                         $related->{$relation->getForeignKeyName()} = $this->model->{$localKey};
                     }
 
+                    // @phpstan-ignore-next-line The value is always iterable at runtime
                     foreach ($prepared[$name] as $column => $value) {
                         $related->setAttribute($column, $value);
                     }
@@ -1115,6 +1134,7 @@ class Form implements Renderable
                         $parent = $relation->getRelated();
                     }
 
+                    // @phpstan-ignore-next-line The value is always iterable at runtime
                     foreach ($prepared[$name] as $column => $value) {
                         $parent->setAttribute($column, $value);
                     }
@@ -1136,6 +1156,7 @@ class Form implements Renderable
                     if (is_null($related)) {
                         $related = $relation->make();
                     }
+                    // @phpstan-ignore-next-line The value is always iterable at runtime
                     foreach ($prepared[$name] as $column => $value) {
                         $related->setAttribute($column, $value);
                     }
@@ -1144,6 +1165,7 @@ class Form implements Renderable
                 case $relation instanceof Relations\HasMany:
                 case $relation instanceof Relations\MorphMany:
 
+                    // @phpstan-ignore-next-line The value is always iterable at runtime
                     foreach ($prepared[$name] as $related) {
                         /** @var Relations\Relation<Model>|\Illuminate\Database\Eloquent\Builder<Model> $relation */
                         $relation = $this->model()->$name();
@@ -1151,8 +1173,10 @@ class Form implements Renderable
                         /** @phpstan-ignore-next-line Call to an undefined method getRelated(). */
                         $keyName = $relation->getRelated()->getKeyName();
 
+                        // @phpstan-ignore-next-line $array is always array|ArrayAccess at runtime
                         $instance = $relation->findOrNew(Arr::get($related, $keyName));
 
+                        // @phpstan-ignore-next-line The value is always an array at runtime
                         if ($related[static::REMOVE_FLAG_NAME] == 1) {
                             /** @phpstan-ignore-next-line Call to an undefined method delete(). */
                             $instance->delete();
@@ -1205,6 +1229,7 @@ class Form implements Renderable
 
             if (is_array($columns)) {
                 foreach ($columns as $name => $column) {
+                    // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
                     Arr::set($prepared, $column, $value[$name]);
                 }
             } elseif (is_string($columns)) {
@@ -1224,7 +1249,9 @@ class Form implements Renderable
     protected function isInvalidColumn($columns, $containsDot = false)
     {
         foreach ((array) $columns as $column) {
+            // @phpstan-ignore-next-line $haystack is always string at runtime
             if ((!$containsDot && Str::contains($column, '.')) ||
+                // @phpstan-ignore-next-line $haystack is always string at runtime
                 ($containsDot && !Str::contains($column, '.'))) {
                 return true;
             }
@@ -1242,16 +1269,21 @@ class Form implements Renderable
      */
     protected function prepareInsert($inserts)
     {
+        // @phpstan-ignore-next-line $inserts is always array at runtime
         if ($this->isHasOneRelation($inserts)) {
+            // @phpstan-ignore-next-line $array is always iterable at runtime
             $inserts = Arr::dot($inserts);
         }
 
+        // @phpstan-ignore-next-line The value is always iterable at runtime
         foreach ($inserts as $column => $value) {
             if (is_null($field = $this->getFieldByColumn($column))) {
+                // @phpstan-ignore-next-line The value is always an array at runtime
                 unset($inserts[$column]);
                 continue;
             }
 
+            // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
             $inserts[$column] = $field->prepare($value);
         }
 
@@ -1263,12 +1295,15 @@ class Form implements Renderable
             }
             
             $column = $field->column();
+            // @phpstan-ignore-next-line The value is always an array at runtime
             $inserts[$column] = $field->prepare(null);
         }
 
         $prepared = [];
 
+        // @phpstan-ignore-next-line The value is always iterable at runtime
         foreach ($inserts as $key => $value) {
+            // @phpstan-ignore-next-line $key is always int|string|null at runtime
             Arr::set($prepared, $key, $value);
         }
 
@@ -1284,16 +1319,21 @@ class Form implements Renderable
      */
     protected function prepareConfirm($inserts)
     {
+        // @phpstan-ignore-next-line $inserts is always array at runtime
         if ($this->isHasOneRelation($inserts)) {
+            // @phpstan-ignore-next-line $array is always iterable at runtime
             $inserts = Arr::dot($inserts);
         }
 
+        // @phpstan-ignore-next-line The value is always iterable at runtime
         foreach ($inserts as $column => $value) {
             if (is_null($field = $this->getFieldByColumn($column))) {
+                // @phpstan-ignore-next-line The value is always an array at runtime
                 unset($inserts[$column]);
                 continue;
             }
 
+            // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
             $inserts[$column] = $field->prepareConfirm($value);
         }
 
@@ -1305,12 +1345,15 @@ class Form implements Renderable
             }
             
             $column = $field->column();
+            // @phpstan-ignore-next-line The value is always an array at runtime
             $inserts[$column] = $field->prepareConfirm(null);
         }
 
         $prepared = [];
 
+        // @phpstan-ignore-next-line The value is always iterable at runtime
         foreach ($inserts as $key => $value) {
+            // @phpstan-ignore-next-line $key is always int|string|null at runtime
             Arr::set($prepared, $key, $value);
         }
 
@@ -1443,6 +1486,7 @@ class Form implements Renderable
         }
 
         if($replicate){
+            // @phpstan-ignore-next-line Assigned value is always Illuminate\Database\Eloquent\Model|null at runtime
             $this->model = $this->replicateModel($this->model, $relations, $ignore);
         }
 
@@ -1450,6 +1494,7 @@ class Form implements Renderable
 
 //        static::doNotSnakeAttributes($this->model);
 
+        // @phpstan-ignore-next-line The value is always an object exposing toArray() at runtime
         $data = $this->model->toArray();
 
         $this->builder->fields()->each(function (Field $field) use ($data) {
@@ -1525,6 +1570,7 @@ class Form implements Renderable
                 continue;
             }
             
+            // @phpstan-ignore-next-line $array is always array at runtime
             $value = array_filter($value);
             if ($relation instanceof Relations\BelongsToMany || $relation instanceof Relations\MorphToMany) {
                 $relations[$column] = (clone $relation->getRelated())->query()->findMany($value);
@@ -1561,12 +1607,14 @@ class Form implements Renderable
      * @return mixed
      */
     protected function replicateModel($oldModel, $relations, $ignore = []){
+        // @phpstan-ignore-next-line The value is always an object exposing replicate() at runtime
         $model = $oldModel->replicate()->setRelations([]);
 
         foreach($ignore as $i){
             unset($model->{$i});
         }
 
+        // @phpstan-ignore-next-line The value is always iterable at runtime
         foreach($relations as $relation){
             // if set hasmany, set model as relation
             if(!($oldModel->{$relation}() instanceof \Illuminate\Database\Eloquent\Relations\HasMany)){
@@ -2199,8 +2247,10 @@ class Form implements Renderable
             $method = static::$fieldAlias[$method];
         }
 
+        // @phpstan-ignore-next-line $key is always int|string|null at runtime
         $class = Arr::get(static::$availableFields, $method);
 
+        // @phpstan-ignore-next-line $class is always string at runtime
         if (class_exists($class)) {
             return $class;
         }
@@ -2223,6 +2273,7 @@ class Form implements Renderable
         $js = collect();
 
         foreach (static::$availableFields as $field) {
+            // @phpstan-ignore-next-line $object_or_class is always object|string at runtime
             if (!method_exists($field, 'getAssets')) {
                 continue;
             }
@@ -2230,7 +2281,9 @@ class Form implements Renderable
             /** @phpstan-ignore-next-line Parameter $callback of function call_user_func expects callable, array{class-string, string} given. */
             $assets = call_user_func([$field, 'getAssets']);
 
+            // @phpstan-ignore-next-line $array is always array|ArrayAccess at runtime
             $css->push(Arr::get($assets, 'css'));
+            // @phpstan-ignore-next-line $array is always array|ArrayAccess at runtime
             $js->push(Arr::get($assets, 'js'));
         }
 

--- a/src/Form/Builder.php
+++ b/src/Form/Builder.php
@@ -147,6 +147,7 @@ class Builder
     public function init()
     {
         $this->tools = new Tools($this);
+        /** @phpstan-ignore-next-line */
         $this->footer = new static::$footerClassName($this);
     }
 
@@ -505,6 +506,7 @@ class Builder
     {
         foreach ($this->fields() as $field) {
             if(method_exists($field, 'hasFile')){
+                /** @phpstan-ignore-next-line */
                 if($field->hasFile()){
                     return true;
                 }

--- a/src/Form/Builder.php
+++ b/src/Form/Builder.php
@@ -273,6 +273,7 @@ class Builder
     public function disablePjax()
     {
         $this->disablePjax = true;
+        /** @phpstan-ignore-next-line class.notFound */
         \Admin::disablePjax();
 
         return $this;

--- a/src/Form/Builder.php
+++ b/src/Form/Builder.php
@@ -257,13 +257,13 @@ class Builder
     public function getResource($slice = null)
     {
         if ($this->mode == self::MODE_CREATE) {
-            return $this->form->resource(-1);
+            return $this->form->resource(-1); // @phpstan-ignore-line Form is guaranteed to be set in Builder
         }
         if ($slice !== null) {
-            return $this->form->resource($slice);
+            return $this->form->resource($slice); // @phpstan-ignore-line Form is guaranteed to be set in Builder
         }
 
-        return $this->form->resource();
+        return $this->form->resource(); // @phpstan-ignore-line Form is guaranteed to be set in Builder
     }
 
     /**
@@ -342,11 +342,11 @@ class Builder
         }
 
         if ($this->isMode(static::MODE_EDIT)) {
-            return $this->form->resource().'/'.$this->id;
+            return $this->form->resource().'/'.$this->id; // @phpstan-ignore-line Form is guaranteed to be set in Builder
         }
 
         if ($this->isMode(static::MODE_CREATE)) {
-            return $this->form->resource(-1);
+            return $this->form->resource(-1); // @phpstan-ignore-line Form is guaranteed to be set in Builder
         }
 
         return '';
@@ -387,6 +387,7 @@ class Builder
      */
     public function fields()
     {
+        // @phpstan-ignore-next-line Fields collection may be null before initialization
         return $this->fields;
     }
 
@@ -421,6 +422,7 @@ class Builder
      */
     public function getRows()
     {
+        // @phpstan-ignore-next-line Form is guaranteed to be set in Builder
         return $this->form->rows;
     }
 
@@ -559,6 +561,7 @@ class Builder
     public function open($options = [])
     {
         // set atribute
+        // @phpstan-ignore-next-line Form is guaranteed to be set in Builder
         $this->form->attribute($options);
 
         if ($this->isMode(self::MODE_EDIT)) {
@@ -567,23 +570,23 @@ class Builder
 
         $this->addRedirectUrlField();
 
-        $this->form->attribute([
+        $this->form->attribute([ // @phpstan-ignore-line Form is guaranteed to be set in Builder
             'action' => url($this->getAction()),
             'method' => Arr::get($options, 'method', 'post'),
             'accept-charset' => 'UTF-8',
-            'data-form_uniquename' => $this->form->getUniqueName(),
-            'class' => $this->form->getUniqueName(),
+            'data-form_uniquename' => $this->form->getUniqueName(), // @phpstan-ignore-line Form is guaranteed to be set in Builder
+            'class' => $this->form->getUniqueName(), // @phpstan-ignore-line Form is guaranteed to be set in Builder
         ]);
-        
+
         if($this->disableValidate){
-            $this->form->attribute('novalidate', 1);
+            $this->form->attribute('novalidate', 1); // @phpstan-ignore-line Form is guaranteed to be set in Builder
         }
         if ($this->hasFile()) {
-            $this->form->attribute('enctype', 'multipart/form-data');
+            $this->form->attribute('enctype', 'multipart/form-data'); // @phpstan-ignore-line Form is guaranteed to be set in Builder
         }
 
         $html = [];
-        foreach ($this->form->getAttributes() as $name => $value) {
+        foreach ($this->form->getAttributes() as $name => $value) { // @phpstan-ignore-line Form is guaranteed to be set in Builder
             $html[] = "$name=\"$value\"";
         }
 
@@ -615,9 +618,9 @@ class Builder
         }
 
         $reservedColumns = [
-            $this->form->model()->getKeyName(),
-            $this->form->model()->getCreatedAtColumn(),
-            $this->form->model()->getUpdatedAtColumn(),
+            $this->form->model()->getKeyName(), // @phpstan-ignore-line Form and Model are guaranteed to be set in Builder
+            $this->form->model()->getCreatedAtColumn(), // @phpstan-ignore-line Form and Model are guaranteed to be set in Builder
+            $this->form->model()->getUpdatedAtColumn(), // @phpstan-ignore-line Form and Model are guaranteed to be set in Builder
         ];
 
         $this->fields = $this->fields()->reject(function (Field $field) use ($reservedColumns) {
@@ -654,6 +657,7 @@ class Builder
     {
         $this->removeReservedFields();
 
+        // @phpstan-ignore-next-line Form is guaranteed to be set in Builder
         $tabObj = $this->form->getTab();
 
         if (!$tabObj->isEmpty()) {

--- a/src/Form/Builder.php
+++ b/src/Form/Builder.php
@@ -45,7 +45,7 @@ class Builder
     protected $action;
 
     /**
-     * @var Collection<int|string, mixed>|null
+     * @var Collection<int|string, Field>|null
      */
     protected $fields;
 
@@ -338,6 +338,7 @@ class Builder
     public function getAction()
     {
         if ($this->action) {
+            // @phpstan-ignore-next-line Return value is always string at runtime
             return $this->action;
         }
 
@@ -383,7 +384,7 @@ class Builder
     /**
      * Get fields of this builder.
      *
-     * @return Collection<int|string, mixed>
+     * @return Collection<int|string, Field>
      */
     public function fields()
     {
@@ -471,6 +472,7 @@ class Builder
     public function option($option, $value = null)
     {
         if (func_num_args() == 1) {
+            // @phpstan-ignore-next-line Return value is always $this(Encore\Admin\Form\Builder) at runtime
             return Arr::get($this->options, $option);
         }
 
@@ -508,7 +510,6 @@ class Builder
     {
         foreach ($this->fields() as $field) {
             if(method_exists($field, 'hasFile')){
-                /** @phpstan-ignore-next-line */
                 if($field->hasFile()){
                     return true;
                 }
@@ -534,12 +535,15 @@ class Builder
         $redirectCamera = request()->get('redirect-camera');
 
         if ($formid) {
+            // @phpstan-ignore-next-line $field is always Encore\Admin\Form\Field at runtime
             $this->addHiddenField((new Hidden(static::FORM_ID))->value($formid));
         }
         if ($redirectDashboard) {
+            // @phpstan-ignore-next-line $field is always Encore\Admin\Form\Field at runtime
             $this->addHiddenField((new Hidden(static::REDIRECT_DASHBOARD))->value($redirectDashboard));
         }
         if ($redirectCamera) {
+            // @phpstan-ignore-next-line $field is always Encore\Admin\Form\Field at runtime
             $this->addHiddenField((new Hidden(static::REDIRECT_CAMERA))->value($redirectCamera));
         }
         if (!$previous || $previous == URL::current()) {
@@ -547,6 +551,7 @@ class Builder
         }
 
         if (Str::contains($previous, url($this->getResource()))) {
+            // @phpstan-ignore-next-line $field is always Encore\Admin\Form\Field at runtime
             $this->addHiddenField((new Hidden(static::PREVIOUS_URL_KEY))->value($previous));
         }
     }
@@ -565,6 +570,7 @@ class Builder
         $this->form->attribute($options);
 
         if ($this->isMode(self::MODE_EDIT)) {
+            // @phpstan-ignore-next-line $field is always Encore\Admin\Form\Field at runtime
             $this->addHiddenField((new Hidden('_method'))->value('PUT'));
         }
 
@@ -587,6 +593,7 @@ class Builder
 
         $html = [];
         foreach ($this->form->getAttributes() as $name => $value) { // @phpstan-ignore-line Form is guaranteed to be set in Builder
+            // @phpstan-ignore-next-line $value is always castable to string at runtime
             $html[] = "$name=\"$value\"";
         }
 

--- a/src/Form/EmbeddedForm.php
+++ b/src/Form/EmbeddedForm.php
@@ -59,7 +59,7 @@ class EmbeddedForm
     /**
      * Fields in form.
      *
-     * @var Collection<int|string, mixed>
+     * @var Collection<int|string, Field>
      */
     protected $fields;
 
@@ -92,7 +92,7 @@ class EmbeddedForm
     /**
      * Get all fields in current form.
      *
-     * @return Collection<int|string, mixed>
+     * @return Collection<int|string, Field>
      */
     public function fields()
     {
@@ -130,6 +130,7 @@ class EmbeddedForm
             $data = json_decode($data, true);
         }
 
+        // @phpstan-ignore-next-line Assigned value is always array at runtime
         $this->original = $data;
 
         return $this;
@@ -146,6 +147,7 @@ class EmbeddedForm
     {
         foreach ($input as $key => $record) {
             $this->setFieldOriginalValue($key);
+            // @phpstan-ignore-next-line $record is always string|null at runtime
             $input[$key] = $this->prepareValue($key, $record, $asConfirm);
         }
 
@@ -155,7 +157,9 @@ class EmbeddedForm
                 continue;
             }
             $key = $field->column();
+            // @phpstan-ignore-next-line $key is always string at runtime
             $this->setFieldOriginalValue($key);
+            // @phpstan-ignore-next-line $key is always string at runtime (and 1 more mixed-type assumption on this line)
             $input[$key] = $this->prepareValue($key, null, $asConfirm);
         }
         
@@ -189,11 +193,9 @@ class EmbeddedForm
         }
 
         if($asConfirm && method_exists($field, 'prepareConfirm')){
-            /** @phpstan-ignore-next-line */
             return $field->prepareConfirm($record);
         }
         if (method_exists($field, 'prepare')) {
-            /** @phpstan-ignore-next-line */
             return $field->prepare($record);
         }
 
@@ -255,12 +257,15 @@ class EmbeddedForm
         
         if (is_array($jsonKey)) {
             foreach ($jsonKey as $index => $name) {
+                // @phpstan-ignore-next-line $formatName is always castable to string at runtime (and 1 more mixed-type assumption on this line)
                 $elementName[$index] = "{$formatName}[$name]";
+                // @phpstan-ignore-next-line $name is always castable to string at runtime
                 $errorKey[$index] = "{$this->column}.$name";
                 /** @phpstan-ignore-next-line */
                 $elementClass[$index] = "{$formatClass}_$name";
             }
         } else {
+            // @phpstan-ignore-next-line $formatName is always castable to string at runtime
             $elementName = "{$formatName}[$jsonKey]";
             $errorKey = "{$this->column}.$jsonKey";
             /** @phpstan-ignore-next-line */

--- a/src/Form/EmbeddedForm.php
+++ b/src/Form/EmbeddedForm.php
@@ -189,9 +189,11 @@ class EmbeddedForm
         }
 
         if($asConfirm && method_exists($field, 'prepareConfirm')){
+            /** @phpstan-ignore-next-line */
             return $field->prepareConfirm($record);
         }
         if (method_exists($field, 'prepare')) {
+            /** @phpstan-ignore-next-line */
             return $field->prepare($record);
         }
 
@@ -255,15 +257,19 @@ class EmbeddedForm
             foreach ($jsonKey as $index => $name) {
                 $elementName[$index] = "{$formatName}[$name]";
                 $errorKey[$index] = "{$this->column}.$name";
+                /** @phpstan-ignore-next-line */
                 $elementClass[$index] = "{$formatClass}_$name";
             }
         } else {
             $elementName = "{$formatName}[$jsonKey]";
             $errorKey = "{$this->column}.$jsonKey";
+            /** @phpstan-ignore-next-line */
             $elementClass = "{$formatClass}_$jsonKey";
         }
 
+        /** @phpstan-ignore-next-line */
         $field->setElementName($elementName)
+            /** @phpstan-ignore-next-line */
             ->setErrorKey($errorKey)
             ->setElementClass($elementClass);
 

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -894,6 +894,7 @@ class Field implements Renderable
         }
 
         $pattern = "/{$rule}[^\|]?(\||$)/";
+        // @phpstan-ignore-next-line preg_replace may return null but rules is always string here
         $this->rules = preg_replace($pattern, '', $this->rules, -1);
     }
 
@@ -1040,6 +1041,7 @@ class Field implements Renderable
      */
     public function getHelpText()
     {
+        // @phpstan-ignore-next-line helpText may be null but return type declares string
         return $this->helpText;
     }
 
@@ -1743,6 +1745,7 @@ class Field implements Renderable
     public function setIndex(?int $index)
     : self
     {
+        // @phpstan-ignore-next-line Index accepts nullable int from parameter
         $this->index = $index;
 
         return $this;
@@ -1916,6 +1919,7 @@ class Field implements Renderable
         }
 
         if ($this->callback instanceof Closure) {
+            // @phpstan-ignore-next-line Form and Model are guaranteed to be set during render
             $this->value = $this->callback->call($this->form->model(), $this->value, $this);
         }
 

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -294,7 +294,7 @@ class Field implements Renderable
     protected $internal = false;
 
     /**
-     * @var \Closure
+     * @var \Closure|null
      */
     protected $prepareConfirm;
 
@@ -555,6 +555,7 @@ class Field implements Renderable
      */
     public function setForm($form = null)
     {
+        /** @phpstan-ignore-next-line Property Encore\\Admin\\Form\\Field::\$form (Encore\\Admin\\Form|null) does not accept Encore\\Admin\\Form|Encore\\Admin\\Widgets\\Form|null. */
         $this->form = $form;
 
         return $this;
@@ -591,6 +592,7 @@ class Field implements Renderable
             $options = $options->toArray();
         }
 
+        /** @phpstan-ignore-next-line Parameter #1 ...\$arrays of function array_merge expects array, array<string, mixed>|Closure given. */
         $this->options = array_merge($this->options, $options);
 
         return $this;
@@ -659,6 +661,7 @@ class Field implements Renderable
             $rules = $this->updateRules ?: $this->rules;
         }
 
+        /** @phpstan-ignore-next-line Parameter #1 $rules of method Encore\Admin\Form\Field::addRequiredAttribute() expects array, array|Closure|string given. */
         $this->addRequiredAttribute($rules);
     }
 
@@ -693,6 +696,7 @@ class Field implements Renderable
                 $original = $this->formatRules($original);
             }
 
+            /** @phpstan-ignore-next-line Parameter #1 ...$arrays of function array_merge expects array, array|string given. */
             $rules = array_merge($original, $this->formatRules($input));
         }
 
@@ -709,6 +713,7 @@ class Field implements Renderable
      */
     public function rules($rules = null, $messages = [])
     {
+        /** @phpstan-ignore-next-line Parameter #1 $input of method Encore\Admin\Form\Field::mergeRules() expects array|Closure|string, array|(callable(): mixed)|string|null given. & Parameter #2 $original of method Encore\Admin\Form\Field::mergeRules() expects array|string, array|Closure|string given. */
         $this->rules = $this->mergeRules($rules, $this->rules);
 
         $this->setValidationMessages('default', $messages);
@@ -726,6 +731,7 @@ class Field implements Renderable
      */
     public function updateRules($rules = null, $messages = [])
     {
+        /** @phpstan-ignore-next-line Parameter #1 $input of method Encore\Admin\Form\Field::mergeRules() expects array|Closure|string, array|(callable(): mixed)|string|null given. & Parameter #2 $original of method Encore\Admin\Form\Field::mergeRules() expects array|string, array|Closure given. */
         $this->updateRules = $this->mergeRules($rules, $this->updateRules);
 
         $this->setValidationMessages('update', $messages);
@@ -743,6 +749,7 @@ class Field implements Renderable
      */
     public function creationRules($rules = null, $messages = [])
     {
+        /** @phpstan-ignore-next-line Parameter #1 $input of method Encore\Admin\Form\Field::mergeRules() expects array|Closure|string, array|(callable(): mixed)|string|null given. & Parameter #2 $original of method Encore\Admin\Form\Field::mergeRules() expects array|string, array|Closure given. */
         $this->creationRules = $this->mergeRules($rules, $this->creationRules);
 
         $this->setValidationMessages('creation', $messages);
@@ -768,8 +775,10 @@ class Field implements Renderable
 
         $newRules = [];
         
+        /** @phpstan-ignore-next-line Argument of an invalid type array|Closure|string supplied for foreach, only iterables are supported. */
         foreach($this->rules as $r){
             $isAdd = true;
+            /** @phpstan-ignore-next-line Argument of an invalid type array|(callable) supplied for foreach, only iterables are supported. */
             foreach($rules as $removeRule){
                 if(is_object($r) && $r instanceof $removeRule){
                     $isAdd = false;
@@ -897,6 +906,7 @@ class Field implements Renderable
      */
     public function validator(callable $validator)
     {
+        /** @phpstan-ignore-next-line Property Encore\Admin\Form\Field::\$validator (Closure|null) does not accept callable(): mixed. */
         $this->validator = $validator;
 
         return $this;
@@ -1158,6 +1168,7 @@ class Field implements Renderable
             }
             
             if(is_string($value) || is_int($value)){
+                /** @phpstan-ignore-next-line Parameter #2 $string of function explode expects string, int|string given. */
                 $value = explode(',', $value);
             }
 
@@ -1317,6 +1328,7 @@ class Field implements Renderable
      */
     public function getPlaceholder()
     {
+        /** @phpstan-ignore-next-line Method Encore\Admin\Form\Field::getPlaceholder() should return string but returns array|string. */
         return $this->placeholder;
         //return $this->placeholder ?: trans('admin.input').' '.$this->label;
     }
@@ -1348,6 +1360,7 @@ class Field implements Renderable
 
             return $olds;
         }else{
+            /** @phpstan-ignore-next-line Parameter #1 $keyname of static method Encore\Admin\Form\Field::getDotName() expects string, array|string given. */
             $keyname = static::getDotName($this->getElementName());
     
             return old($keyname, $value);
@@ -1381,7 +1394,6 @@ class Field implements Renderable
      */
     public function prepareConfirm($value)
     {
-        /** @phpstan-ignore-next-line Negated boolean expression is always false. */
         if(!$this->prepareConfirm){
             return $this->prepare($value);
         }

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -308,6 +308,7 @@ class Field implements Renderable
      */
     public function __construct($column = '', $arguments = [])
     {
+        // @phpstan-ignore-next-line Assigned value is always array|string at runtime
         $this->column = $this->formatColumn($column);
         $this->label = $this->formatLabel($arguments);
         $this->id = $this->formatId($column);
@@ -407,8 +408,10 @@ class Field implements Renderable
     {
         $column = is_array($this->column) ? current($this->column) : $this->column;
 
+        // @phpstan-ignore-next-line $string is always string at runtime
         $label = isset($arguments[0]) ? $arguments[0] : ucfirst($column);
 
+        // @phpstan-ignore-next-line $subject is always array|string at runtime
         return str_replace(['.', '_', '->'], ' ', $label);
     }
 
@@ -443,6 +446,7 @@ class Field implements Renderable
         if (is_array($this->column)) {
             $names = [];
             foreach ($this->column as $key => $name) {
+                // @phpstan-ignore-next-line $column is always array|string at runtime
                 $names[$key] = $this->formatName($name);
             }
 
@@ -476,6 +480,7 @@ class Field implements Renderable
      */
     public function getElementName()
     {
+        // @phpstan-ignore-next-line Return value is always array|string at runtime
         return $this->elementName ?: $this->formatName($this->column);
     }
 
@@ -492,6 +497,7 @@ class Field implements Renderable
 
         if (is_array($this->column)) {
             foreach ($this->column as $key => $column) {
+                // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
                 $this->value[$key] = Arr::get($data, $column);
             }
 
@@ -539,6 +545,7 @@ class Field implements Renderable
     {
         if (is_array($this->column)) {
             foreach ($this->column as $key => $column) {
+                // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
                 $this->original[$key] = Arr::get($data, $column);
             }
 
@@ -796,6 +803,7 @@ class Field implements Renderable
                 $newRules = $r;
             }
         }
+        // @phpstan-ignore-next-line Assigned value is always array|Closure|string at runtime
         $this->rules = $newRules;
 
         return $this;
@@ -858,19 +866,24 @@ class Field implements Renderable
         }
 
         if (!$this->form || !$this->form->model()) {
+            // @phpstan-ignore-next-line Return value is always array|Closure|string at runtime
             return $rules;
         }
 
         if (!$id = $this->form->model()->getKey()) {
+            // @phpstan-ignore-next-line Return value is always array|Closure|string at runtime
             return $rules;
         }
 
+        // @phpstan-ignore-next-line The value is always iterable at runtime
         foreach ($rules as &$rule) {
             if (is_string($rule)) {
+                // @phpstan-ignore-next-line $replace is always array|string at runtime
                 $rule = str_replace('{{id}}', $id, $rule);
             }
         }
 
+        // @phpstan-ignore-next-line Return value is always array|Closure|string at runtime
         return $rules;
     }
 
@@ -920,6 +933,7 @@ class Field implements Renderable
      */
     public function getErrorKey()
     {
+        // @phpstan-ignore-next-line Return value is always string at runtime
         return $this->errorKey ?: $this->column;
     }
 
@@ -965,6 +979,7 @@ class Field implements Renderable
     public function data(array $data = null)
     {
         if (is_null($data)) {
+            // @phpstan-ignore-next-line Return value is always $this(Encore\Admin\Form\Field) at runtime
             return $this->data;
         }
 
@@ -1141,6 +1156,7 @@ class Field implements Renderable
 
         if (is_array($this->column)) {
             foreach ($this->column as $key => $column) {
+                // @phpstan-ignore-next-line $key is always int|string at runtime
                 if (!array_key_exists($column, $input)) {
                     continue;
                 }
@@ -1150,6 +1166,7 @@ class Field implements Renderable
             }
         }
 
+        // @phpstan-ignore-next-line $messages is always array at runtime
         return \validator($input, $rules, $this->getValidationMessages(), $attributes);
     }
 
@@ -1178,6 +1195,7 @@ class Field implements Renderable
                 $value = $value->toArray();
             }
 
+            // @phpstan-ignore-next-line $array is always array at runtime
             Arr::set($input, $column, array_filter($value));
         }
 
@@ -1197,6 +1215,7 @@ class Field implements Renderable
         if (is_array($attribute)) {
             $this->attributes = array_merge($this->attributes, $attribute);
         } else {
+            // @phpstan-ignore-next-line The value is always castable to string at runtime
             $this->attributes[$attribute] = (string) $value;
         }
 
@@ -1349,9 +1368,11 @@ class Field implements Renderable
                 $elementNames = $this->getElementName();
                 $elementName = is_array($elementNames) ? Arr::get($elementNames, $key) : $elementNames;
 
+                // @phpstan-ignore-next-line $keyname is always string at runtime
                 $keyname = static::getDotName($elementName);
                 $v = Arr::get((is_null($value) ? [] : (array)$value), $key);
 
+                // @phpstan-ignore-next-line $key is always string|null at runtime
                 if(!is_null($old = old($c, $v))){
                     $olds[$key] = $old;
                 }
@@ -1425,6 +1446,7 @@ class Field implements Renderable
         $html = [];
 
         foreach ($this->attributes as $name => $value) {
+            // @phpstan-ignore-next-line $value is always BackedEnum|Illuminate\Contracts\Support\DeferringDisplayableValue|Illuminate\Contracts\Support\Htmlable|string|null at runtime
             $html[] = $name.'="'.e($value).'"';
         }
 
@@ -1507,6 +1529,7 @@ class Field implements Renderable
         if (!$this->elementClass) {
             $name = $this->elementName ?: $this->formatName($this->column);
 
+            // @phpstan-ignore-next-line $subject is always array|string at runtime
             $this->elementClass = (array) str_replace(['[', ']'], '_', $name);
         }
 

--- a/src/Form/Field/Button.php
+++ b/src/Form/Field/Button.php
@@ -28,7 +28,7 @@ class Button extends Field
      */
     public function on($event, $callback)
     {
-        /** @phpstan-ignore-next-line argument.type */
+        /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
         $this->script = <<<EOT
 
         $('{$this->getElementClassSelector()}').on('$event', function() {

--- a/src/Form/Field/Button.php
+++ b/src/Form/Field/Button.php
@@ -28,10 +28,11 @@ class Button extends Field
      */
     public function on($event, $callback)
     {
-        /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
+        /** @var string $selector */
+        $selector = $this->getElementClassSelector();
         $this->script = <<<EOT
 
-        $('{$this->getElementClassSelector()}').on('$event', function() {
+        $('{$selector}').on('$event', function() {
             $callback
         });
 

--- a/src/Form/Field/Button.php
+++ b/src/Form/Field/Button.php
@@ -28,6 +28,7 @@ class Button extends Field
      */
     public function on($event, $callback)
     {
+        /** @phpstan-ignore-next-line argument.type */
         $this->script = <<<EOT
 
         $('{$this->getElementClassSelector()}').on('$event', function() {

--- a/src/Form/Field/Button.php
+++ b/src/Form/Field/Button.php
@@ -28,7 +28,7 @@ class Button extends Field
      */
     public function on($event, $callback)
     {
-        /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
+        /** @phpstan-ignore-next-line argument.type */
         $this->script = <<<EOT
 
         $('{$this->getElementClassSelector()}').on('$event', function() {

--- a/src/Form/Field/Captcha.php
+++ b/src/Form/Field/Captcha.php
@@ -39,10 +39,11 @@ class Captcha extends Text
 
     public function render()
     {
-        /** @phpstan-ignore-next-line Part $this->column (array|string) of encapsed string cannot be cast to string. */
+        /** @var string $column */
+        $column = $this->column;
         $this->script = <<<EOT
 
-$('#{$this->column}-captcha').click(function () {
+$('#{$column}-captcha').click(function () {
     $(this).attr('src', $(this).attr('src')+'?'+Math.random());
 });
 

--- a/src/Form/Field/Captcha.php
+++ b/src/Form/Field/Captcha.php
@@ -28,8 +28,10 @@ class Captcha extends Text
 
     public function setForm($form = null)
     {
+        /** @phpstan-ignore-next-line Property Encore\Admin\Form\Field::$form (Encore\Admin\Form|null) does not accept Encore\Admin\Form|Encore\Admin\Widgets\Form|null. */
         $this->form = $form;
 
+        /** @phpstan-ignore-next-line Call to an undefined method Encore\Admin\Form|Encore\Admin\Widgets\Form::ignore(). */
         $this->form->ignore($this->column);
 
         return $this;
@@ -37,6 +39,7 @@ class Captcha extends Text
 
     public function render()
     {
+        /** @phpstan-ignore-next-line Part $this->column (array|string) of encapsed string cannot be cast to string. */
         $this->script = <<<EOT
 
 $('#{$this->column}-captcha').click(function () {

--- a/src/Form/Field/Captcha.php
+++ b/src/Form/Field/Captcha.php
@@ -39,7 +39,7 @@ class Captcha extends Text
 
     public function render()
     {
-        /** @phpstan-ignore-next-line Part $this->column (array|string) of encapsed string cannot be cast to string. */
+        /** @phpstan-ignore-next-line argument.type */
         $this->script = <<<EOT
 
 $('#{$this->column}-captcha').click(function () {

--- a/src/Form/Field/Captcha.php
+++ b/src/Form/Field/Captcha.php
@@ -39,7 +39,7 @@ class Captcha extends Text
 
     public function render()
     {
-        /** @phpstan-ignore-next-line argument.type */
+        /** @phpstan-ignore-next-line Part $this->column (array|string) of encapsed string cannot be cast to string. */
         $this->script = <<<EOT
 
 $('#{$this->column}-captcha').click(function () {

--- a/src/Form/Field/Checkbox.php
+++ b/src/Form/Field/Checkbox.php
@@ -45,6 +45,7 @@ class Checkbox extends MultipleSelect
         }
 
         if (is_callable($options)) {
+            /** @phpstan-ignore-next-line */
             $this->options = $options;
         } else {
             $this->options = (array) $options;
@@ -116,6 +117,7 @@ class Checkbox extends MultipleSelect
         Arr::forget($this->attributes, 'required');
         $this->removeRules(['required']);
 
+        /** @phpstan-ignore-next-line argument.type */
         $this->script = "$('{$this->getElementClassSelector()}').iCheck({checkboxClass:'icheckbox_minimal-blue'});";
 
         $this->addVariables([
@@ -127,6 +129,7 @@ class Checkbox extends MultipleSelect
         if ($this->canCheckAll) {
             $checkAllClass = uniqid('check-all-');
 
+            /** @phpstan-ignore-next-line argument.type */
             $this->script .= <<<SCRIPT
 $('.{$checkAllClass}').iCheck({checkboxClass:'icheckbox_minimal-blue'}).on('ifChanged', function () {
     if (this.checked) {

--- a/src/Form/Field/Checkbox.php
+++ b/src/Form/Field/Checkbox.php
@@ -128,13 +128,15 @@ class Checkbox extends MultipleSelect
 
         if ($this->canCheckAll) {
             $checkAllClass = uniqid('check-all-');
+            /** @var string $selector */
+            $selector = $this->getElementClassSelector();
 
             $this->script .= <<<SCRIPT
 $('.{$checkAllClass}').iCheck({checkboxClass:'icheckbox_minimal-blue'}).on('ifChanged', function () {
     if (this.checked) {
-        $('{$this->getElementClassSelector()}').iCheck('check');
+        $('{$selector}').iCheck('check');
     } else {
-        $('{$this->getElementClassSelector()}').iCheck('uncheck');
+        $('{$selector}').iCheck('uncheck');
     }
 })
 SCRIPT;

--- a/src/Form/Field/Checkbox.php
+++ b/src/Form/Field/Checkbox.php
@@ -129,12 +129,13 @@ class Checkbox extends MultipleSelect
         if ($this->canCheckAll) {
             $checkAllClass = uniqid('check-all-');
 
-            /** @phpstan-ignore-next-line argument.type */
             $this->script .= <<<SCRIPT
 $('.{$checkAllClass}').iCheck({checkboxClass:'icheckbox_minimal-blue'}).on('ifChanged', function () {
     if (this.checked) {
+        /** @phpstan-ignore-next-line Part \$this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
         $('{$this->getElementClassSelector()}').iCheck('check');
     } else {
+        /** @phpstan-ignore-next-line Part \$this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
         $('{$this->getElementClassSelector()}').iCheck('uncheck');
     }
 })

--- a/src/Form/Field/Checkbox.php
+++ b/src/Form/Field/Checkbox.php
@@ -129,7 +129,6 @@ class Checkbox extends MultipleSelect
         if ($this->canCheckAll) {
             $checkAllClass = uniqid('check-all-');
 
-            /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
             $this->script .= <<<SCRIPT
 $('.{$checkAllClass}').iCheck({checkboxClass:'icheckbox_minimal-blue'}).on('ifChanged', function () {
     if (this.checked) {

--- a/src/Form/Field/Checkbox.php
+++ b/src/Form/Field/Checkbox.php
@@ -129,13 +129,12 @@ class Checkbox extends MultipleSelect
         if ($this->canCheckAll) {
             $checkAllClass = uniqid('check-all-');
 
+            /** @phpstan-ignore-next-line argument.type */
             $this->script .= <<<SCRIPT
 $('.{$checkAllClass}').iCheck({checkboxClass:'icheckbox_minimal-blue'}).on('ifChanged', function () {
     if (this.checked) {
-        /** @phpstan-ignore-next-line Part \$this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
         $('{$this->getElementClassSelector()}').iCheck('check');
     } else {
-        /** @phpstan-ignore-next-line Part \$this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
         $('{$this->getElementClassSelector()}').iCheck('uncheck');
     }
 })

--- a/src/Form/Field/Checkbox.php
+++ b/src/Form/Field/Checkbox.php
@@ -129,7 +129,7 @@ class Checkbox extends MultipleSelect
         if ($this->canCheckAll) {
             $checkAllClass = uniqid('check-all-');
 
-            /** @phpstan-ignore-next-line argument.type */
+            /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
             $this->script .= <<<SCRIPT
 $('.{$checkAllClass}').iCheck({checkboxClass:'icheckbox_minimal-blue'}).on('ifChanged', function () {
     if (this.checked) {

--- a/src/Form/Field/Color.php
+++ b/src/Form/Field/Color.php
@@ -55,6 +55,7 @@ class Color extends Text
     {
         $options = json_encode($this->options);
 
+        /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
         $this->script = "$('{$this->getElementClassSelector()}').parent().colorpicker($options);";
 
         $this->prepend('<i></i>')

--- a/src/Form/Field/Currency.php
+++ b/src/Form/Field/Currency.php
@@ -59,6 +59,7 @@ class Currency extends Text
      */
     public function prepare($value)
     {
+        // @phpstan-ignore-next-line The value is always castable to float at runtime
         return (float) $value;
     }
 

--- a/src/Form/Field/Date.php
+++ b/src/Form/Field/Date.php
@@ -53,10 +53,12 @@ class Date extends Text
      */
     public function render()
     {
+        /** @phpstan-ignore-next-line Cannot access offset 'format' on array<string, mixed>|Closure. */
         $this->options['format'] = $this->format;
         $this->options['locale'] = config('app.locale');
         $this->options['allowInputToggle'] = true;
 
+        /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
         $this->script = "$('{$this->getElementClassSelector()}').parent().datetimepicker(".json_encode($this->options).');';
 
         $this->prepend('<i class="fa fa-calendar fa-fw"></i>')

--- a/src/Form/Field/DateRange.php
+++ b/src/Form/Field/DateRange.php
@@ -97,8 +97,7 @@ class DateRange extends Field
 
         $class = $this->getElementClassSelector();
 
-        /** @phpstan-ignore-next-line Offset 'start' does not exist on array|string. */
-        /** @phpstan-ignore-next-line Offset 'end' does not exist on array|string. */
+        /** @phpstan-ignore-next-line Offset 'start' does not exist on array|string. Offset 'end' does not exist on array|string. */
         $this->script = <<<EOT
             $('{$class['start']}').datetimepicker($startOptions);
             $('{$class['end']}').datetimepicker($endOptions);

--- a/src/Form/Field/DateRange.php
+++ b/src/Form/Field/DateRange.php
@@ -96,15 +96,20 @@ class DateRange extends Field
         $endOptions = json_encode($this->options + ['useCurrent' => false]);
 
         $class = $this->getElementClassSelector();
+        
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var array{start: string, end: string} $class */
+        $startClass = $class['start'];
+        $endClass = $class['end'];
 
         $this->script = <<<EOT
-            $('{$class['start']}').datetimepicker($startOptions);
-            $('{$class['end']}').datetimepicker($endOptions);
-            $("{$class['start']}").on("dp.change", function (e) {
-                $('{$class['end']}').data("DateTimePicker").minDate(e.date);
+            $('{$startClass}').datetimepicker($startOptions);
+            $('{$endClass}').datetimepicker($endOptions);
+            $("{$startClass}").on("dp.change", function (e) {
+                $('{$endClass}').data("DateTimePicker").minDate(e.date);
             });
-            $("{$class['end']}").on("dp.change", function (e) {
-                $('{$class['start']}').data("DateTimePicker").maxDate(e.date);
+            $("{$endClass}").on("dp.change", function (e) {
+                $('{$startClass}').data("DateTimePicker").maxDate(e.date);
             });
 EOT;
 

--- a/src/Form/Field/DateRange.php
+++ b/src/Form/Field/DateRange.php
@@ -98,7 +98,6 @@ class DateRange extends Field
         $class = $this->getElementClassSelector();
 
         /** @phpstan-ignore-next-line Offset 'start' does not exist on array|string. */
-        /** @phpstan-ignore-next-line Offset 'end' does not exist on array|string. */
         $this->script = <<<EOT
             $('{$class['start']}').datetimepicker($startOptions);
             $('{$class['end']}').datetimepicker($endOptions);

--- a/src/Form/Field/DateRange.php
+++ b/src/Form/Field/DateRange.php
@@ -97,7 +97,8 @@ class DateRange extends Field
 
         $class = $this->getElementClassSelector();
 
-        /** @phpstan-ignore-next-line Offset 'start' does not exist on array|string. Offset 'end' does not exist on array|string. */
+        /** @phpstan-ignore-next-line Offset 'start' does not exist on array|string. */
+        /** @phpstan-ignore-next-line Offset 'end' does not exist on array|string. */
         $this->script = <<<EOT
             $('{$class['start']}').datetimepicker($startOptions);
             $('{$class['end']}').datetimepicker($endOptions);

--- a/src/Form/Field/DateRange.php
+++ b/src/Form/Field/DateRange.php
@@ -57,10 +57,13 @@ class DateRange extends Field
     public function value($value = null)
     {
         if (is_null($value)) {
+            // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
             if (!isset($this->value['start']) && !isset($this->value['end'])) {
+                // @phpstan-ignore-next-line Return value is always $this(Encore\Admin\Form\Field\DateRange) at runtime
                 return $this->getDefault();
             }
 
+            // @phpstan-ignore-next-line Return value is always $this(Encore\Admin\Form\Field\DateRange) at runtime
             return $this->value;
         }
 

--- a/src/Form/Field/DateRange.php
+++ b/src/Form/Field/DateRange.php
@@ -97,7 +97,6 @@ class DateRange extends Field
 
         $class = $this->getElementClassSelector();
 
-        /** @phpstan-ignore-next-line Offset 'start' does not exist on array|string. */
         $this->script = <<<EOT
             $('{$class['start']}').datetimepicker($startOptions);
             $('{$class['end']}').datetimepicker($endOptions);

--- a/src/Form/Field/DateRange.php
+++ b/src/Form/Field/DateRange.php
@@ -89,6 +89,7 @@ class DateRange extends Field
      */
     public function render()
     {
+        /** @phpstan-ignore-next-line Cannot access offset 'locale' on array<string, mixed>|Closure. */
         $this->options['locale'] = config('app.locale');
 
         $startOptions = json_encode($this->options);
@@ -96,6 +97,8 @@ class DateRange extends Field
 
         $class = $this->getElementClassSelector();
 
+        /** @phpstan-ignore-next-line Offset 'start' does not exist on array|string. */
+        /** @phpstan-ignore-next-line Offset 'end' does not exist on array|string. */
         $this->script = <<<EOT
             $('{$class['start']}').datetimepicker($startOptions);
             $('{$class['end']}').datetimepicker($endOptions);

--- a/src/Form/Field/Editor.php
+++ b/src/Form/Field/Editor.php
@@ -12,6 +12,7 @@ class Editor extends Field
 
     public function render()
     {
+        /** @phpstan-ignore-next-line Part \$this->id (array|string) of encapsed string cannot be cast to string. */
         $this->script = "CKEDITOR.replace('{$this->id}');";
 
         return parent::render();

--- a/src/Form/Field/Embeds.php
+++ b/src/Form/Field/Embeds.php
@@ -69,6 +69,7 @@ class Embeds extends Field
      */
     public function getValidator(array $input)
     {
+        /** @phpstan-ignore-next-line Parameter #1 $key of function array_key_exists expects int|string, array|string given. */
         if (!array_key_exists($this->column, $input)) {
             return false;
         }
@@ -107,11 +108,13 @@ class Embeds extends Field
              */
             if (is_array($column)) {
                 foreach ($column as $key => $name) {
+                    /** @phpstan-ignore-next-line Part $this->column (array|string) of encapsed string cannot be cast to string. */
                     $rules["{$this->column}.$name$key"] = $fieldRules;
                 }
 
                 $this->resetInputKey($input, $column);
             } else {
+                /** @phpstan-ignore-next-line Part $this->column (array|string) of encapsed string cannot be cast to string. */
                 $rules["{$this->column}.$column"] = $fieldRules;
             }
 
@@ -217,6 +220,7 @@ class Embeds extends Field
     {
         $column = array_flip($column);
 
+        /** @phpstan-ignore-next-line Possibly invalid array key type array|string. */
         foreach ($input[$this->column] as $key => $value) {
             if (!array_key_exists($key, $column)) {
                 continue;
@@ -227,10 +231,12 @@ class Embeds extends Field
             /*
              * set new key
              */
+            /** @phpstan-ignore-next-line Part $this->column (array|string) of encapsed string cannot be cast to string. */
             Arr::set($input, "{$this->column}.$newKey", $value);
             /*
              * forget the old key and value
              */
+            /** @phpstan-ignore-next-line Part $this->column (array|string) of encapsed string cannot be cast to string. */
             Arr::forget($input, "{$this->column}.$key");
         }
     }
@@ -246,6 +252,7 @@ class Embeds extends Field
      */
     protected function getEmbeddedData()
     {
+        /** @phpstan-ignore-next-line Parameter #1 $key of function old expects string|null, array|string given. */
         if ($old = old($this->column)) {
             return $old;
         }
@@ -268,6 +275,7 @@ class Embeds extends Field
      */
     protected function buildEmbeddedForm()
     {
+        /** @phpstan-ignore-next-line Parameter #1 $column of class Encore\Admin\Form\EmbeddedForm constructor expects string, array|string given. */
         $form = new EmbeddedForm($this->column);
 
         $form->setParent($this->form);

--- a/src/Form/Field/Embeds.php
+++ b/src/Form/Field/Embeds.php
@@ -278,6 +278,7 @@ class Embeds extends Field
         /** @phpstan-ignore-next-line Parameter #1 $column of class Encore\Admin\Form\EmbeddedForm constructor expects string, array|string given. */
         $form = new EmbeddedForm($this->column);
 
+        // @phpstan-ignore-next-line Form is guaranteed to be set when building embedded form
         $form->setParent($this->form);
 
         call_user_func($this->builder, $form);

--- a/src/Form/Field/Embeds.php
+++ b/src/Form/Field/Embeds.php
@@ -26,10 +26,12 @@ class Embeds extends Field
 
         if (count($arguments) == 1) {
             $this->label = $this->formatLabel();
+            // @phpstan-ignore-next-line Assigned value is always Closure at runtime
             $this->builder = $arguments[0];
         }
 
         if (count($arguments) == 2) {
+            // @phpstan-ignore-next-line Assigned value is always string at runtime (and 1 more mixed-type assumption on this line)
             list($this->label, $this->builder) = $arguments;
         }
     }
@@ -45,6 +47,7 @@ class Embeds extends Field
     {
         $form = $this->buildEmbeddedForm();
 
+        // @phpstan-ignore-next-line Return value is always array at runtime (and 1 more mixed-type assumption on this line)
         return $form->setOriginal($this->original)->prepare($input);
     }
 
@@ -59,6 +62,7 @@ class Embeds extends Field
     {
         $form = $this->buildEmbeddedForm();
 
+        // @phpstan-ignore-next-line Return value is always array at runtime (and 1 more mixed-type assumption on this line)
         return $form->setOriginal($this->original)->prepare($input, true);
     }
 
@@ -147,6 +151,7 @@ class Embeds extends Field
             return false;
         }
 
+        // @phpstan-ignore-next-line $messages is always array at runtime
         return \validator($input, $rules, $this->getValidationMessages(), $attributes);
     }
 
@@ -199,6 +204,7 @@ class Embeds extends Field
             } else {
                 foreach ($new as $k => $val) {
                     if (Str::endsWith($key, ".$k")) {
+                        // @phpstan-ignore-next-line $val is always castable to string at runtime
                         $attributes[$key] = $label."[$val]";
                     }
                 }
@@ -218,10 +224,12 @@ class Embeds extends Field
      */
     public function resetInputKey(array &$input, array $column)
     {
+        // @phpstan-ignore-next-line $array is always array<int|string> at runtime
         $column = array_flip($column);
 
         /** @phpstan-ignore-next-line Possibly invalid array key type array|string. */
         foreach ($input[$this->column] as $key => $value) {
+            // @phpstan-ignore-next-line $key is always int|string at runtime
             if (!array_key_exists($key, $column)) {
                 continue;
             }
@@ -254,6 +262,7 @@ class Embeds extends Field
     {
         /** @phpstan-ignore-next-line Parameter #1 $key of function old expects string|null, array|string given. */
         if ($old = old($this->column)) {
+            // @phpstan-ignore-next-line Return value is always array at runtime
             return $old;
         }
 
@@ -262,6 +271,7 @@ class Embeds extends Field
         }
 
         if (is_string($this->value)) {
+            // @phpstan-ignore-next-line Return value is always array at runtime
             return json_decode($this->value, true);
         }
 

--- a/src/Form/Field/File.php
+++ b/src/Form/Field/File.php
@@ -116,6 +116,7 @@ class File extends Field
         /** @phpstan-ignore-next-line Possibly invalid array key type array|string. */
         $attributes[$this->column] = $this->label;
 
+        // @phpstan-ignore-next-line $messages is always array at runtime
         return \validator($input, $rules, $this->getValidationMessages(), $attributes);
     }
 
@@ -181,6 +182,7 @@ class File extends Field
      */
     protected function preview()
     {
+        // @phpstan-ignore-next-line $path is always string at runtime
         return $this->objectUrl($this->value);
     }
 
@@ -237,6 +239,7 @@ class File extends Field
     protected function initialCaption($caption, $key)
     {
         if($this->caption instanceof Closure){
+            // @phpstan-ignore-next-line Return value is always string at runtime
             return $this->caption->call($this, $caption, $key);
         }
         return basename($caption);
@@ -248,6 +251,7 @@ class File extends Field
     protected function initialPreviewConfig()
     {
         $key = $this->initialFileIndex($this->value);
+        // @phpstan-ignore-next-line $caption is always string at runtime
         $config = ['caption' => $this->initialCaption($this->value, $key), 'key' => $key];
 
         /** @phpstan-ignore-next-line */
@@ -312,6 +316,8 @@ EOT;
 
             /** @phpstan-ignore-next-line Cannot access offset 'deletedEvent' on array<string, mixed>|Closure. */
             if(isset($this->options['deletedEvent'])){
+                // Type assertion for PHPStan - maintain original behavior
+                /** @var string $deletedEvent */
                 $deletedEvent = $this->options['deletedEvent'];
                 $this->script .= <<<EOT
                 $("{$selector}").on('filedeleted', function(event, key, jqXHR, data) {
@@ -343,6 +349,7 @@ EOT;
             /** @phpstan-ignore-next-line Parameter #1 $array of static method Illuminate\Support\Arr::get() expects array|ArrayAccess, array<string, mixed>|Closure given. */
             $this->attribute('data-initial-caption', Arr::get($this->options, 'initialPreviewConfig.0.caption'));
 
+            // @phpstan-ignore-next-line $file is always string at runtime
             $previewType = $this->guessPreviewType($this->value);
             /** @phpstan-ignore-next-line Parameter #1 $array of static method Illuminate\Support\Arr::get() expects array|ArrayAccess, array<string>|bool given. */
             $this->attribute('data-initial-type', Arr::get($previewType, 'type'));

--- a/src/Form/Field/File.php
+++ b/src/Form/Field/File.php
@@ -262,7 +262,6 @@ class File extends Field
      */
     protected function setupScripts($options)
     {
-        /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
         $this->script = <<<EOT
 $("{$this->getElementClassSelector()}").each(function(index, element){
     var options = {$options};
@@ -283,7 +282,6 @@ EOT;
                 'cancel'  => trans('admin.cancel'),
             ];
 
-            /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
             $this->script .= <<<EOT
 $("{$this->getElementClassSelector()}").on('filebeforedelete', function() {
     
@@ -313,7 +311,6 @@ EOT;
             /** @phpstan-ignore-next-line Cannot access offset 'deletedEvent' on array<string, mixed>|Closure. */
             if(isset($this->options['deletedEvent'])){
                 $deletedEvent = $this->options['deletedEvent'];
-                /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
                 $this->script .= <<<EOT
                 $("{$this->getElementClassSelector()}").on('filedeleted', function(event, key, jqXHR, data) {
                     {$deletedEvent};
@@ -341,13 +338,13 @@ EOT;
             $this->setupPreviewOptions();
 
             $this->attribute('data-initial-preview', $this->preview());
-            /** @phpstan-ignore-next-line */
+            /** @phpstan-ignore-next-line Parameter #1 $array of static method Illuminate\Support\Arr::get() expects array|ArrayAccess, array<string, mixed>|Closure given. */
             $this->attribute('data-initial-caption', Arr::get($this->options, 'initialPreviewConfig.0.caption'));
 
             $previewType = $this->guessPreviewType($this->value);
-            /** @phpstan-ignore-next-line */
+            /** @phpstan-ignore-next-line Parameter #1 $array of static method Illuminate\Support\Arr::get() expects array|ArrayAccess, array<string>|bool given. */
             $this->attribute('data-initial-type', Arr::get($previewType, 'type'));
-            /** @phpstan-ignore-next-line */
+            /** @phpstan-ignore-next-line Parameter #1 $array of static method Illuminate\Support\Arr::get() expects array|ArrayAccess, array<string>|bool given. */
             $this->attribute('data-initial-download-url', Arr::get($previewType, 'downloadUrl'));
             /*
              * If has original value, means the form is in edit mode,
@@ -356,7 +353,7 @@ EOT;
             unset($this->attributes['required']);
         }
 
-        /** @phpstan-ignore-next-line */
+        /** @phpstan-ignore-next-line Parameter #1 $options of function json_encode_options expects array, array<string, mixed>|Closure given. */
         $options = json_encode_options($this->options);
 
         $this->setupScripts($options);

--- a/src/Form/Field/File.php
+++ b/src/Form/Field/File.php
@@ -250,6 +250,7 @@ class File extends Field
         $key = $this->initialFileIndex($this->value);
         $config = ['caption' => $this->initialCaption($this->value, $key), 'key' => $key];
 
+        /** @phpstan-ignore-next-line */
         $config = array_merge($config, $this->guessPreviewType($this->value));
 
         return [$config];
@@ -261,6 +262,7 @@ class File extends Field
      */
     protected function setupScripts($options)
     {
+        /** @phpstan-ignore-next-line argument.type */
         $this->script = <<<EOT
 $("{$this->getElementClassSelector()}").each(function(index, element){
     var options = {$options};
@@ -281,6 +283,7 @@ EOT;
                 'cancel'  => trans('admin.cancel'),
             ];
 
+            /** @phpstan-ignore-next-line argument.type */
             $this->script .= <<<EOT
 $("{$this->getElementClassSelector()}").on('filebeforedelete', function() {
     
@@ -307,8 +310,11 @@ $("{$this->getElementClassSelector()}").on('filebeforedelete', function() {
 
 EOT;
 
+            /** @phpstan-ignore-next-line Cannot access offset 'deletedEvent' on array<string, mixed>|Closure. */
             if(isset($this->options['deletedEvent'])){
+                /** @phpstan-ignore-next-line Cannot access offset 'deletedEvent' on array<string, mixed>|Closure. */
                 $deletedEvent = $this->options['deletedEvent'];
+                /** @phpstan-ignore-next-line argument.type */
                 $this->script .= <<<EOT
                 $("{$this->getElementClassSelector()}").on('filedeleted', function(event, key, jqXHR, data) {
                     {$deletedEvent};
@@ -336,10 +342,13 @@ EOT;
             $this->setupPreviewOptions();
 
             $this->attribute('data-initial-preview', $this->preview());
+            /** @phpstan-ignore-next-line */
             $this->attribute('data-initial-caption', Arr::get($this->options, 'initialPreviewConfig.0.caption'));
 
             $previewType = $this->guessPreviewType($this->value);
+            /** @phpstan-ignore-next-line */
             $this->attribute('data-initial-type', Arr::get($previewType, 'type'));
+            /** @phpstan-ignore-next-line */
             $this->attribute('data-initial-download-url', Arr::get($previewType, 'downloadUrl'));
             /*
              * If has original value, means the form is in edit mode,
@@ -348,6 +357,7 @@ EOT;
             unset($this->attributes['required']);
         }
 
+        /** @phpstan-ignore-next-line */
         $options = json_encode_options($this->options);
 
         $this->setupScripts($options);

--- a/src/Form/Field/File.php
+++ b/src/Form/Field/File.php
@@ -262,7 +262,7 @@ class File extends Field
      */
     protected function setupScripts($options)
     {
-        /** @phpstan-ignore-next-line argument.type */
+        /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
         $this->script = <<<EOT
 $("{$this->getElementClassSelector()}").each(function(index, element){
     var options = {$options};
@@ -283,7 +283,7 @@ EOT;
                 'cancel'  => trans('admin.cancel'),
             ];
 
-            /** @phpstan-ignore-next-line argument.type */
+            /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
             $this->script .= <<<EOT
 $("{$this->getElementClassSelector()}").on('filebeforedelete', function() {
     
@@ -312,9 +312,8 @@ EOT;
 
             /** @phpstan-ignore-next-line Cannot access offset 'deletedEvent' on array<string, mixed>|Closure. */
             if(isset($this->options['deletedEvent'])){
-                /** @phpstan-ignore-next-line Cannot access offset 'deletedEvent' on array<string, mixed>|Closure. */
                 $deletedEvent = $this->options['deletedEvent'];
-                /** @phpstan-ignore-next-line argument.type */
+                /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
                 $this->script .= <<<EOT
                 $("{$this->getElementClassSelector()}").on('filedeleted', function(event, key, jqXHR, data) {
                     {$deletedEvent};

--- a/src/Form/Field/File.php
+++ b/src/Form/Field/File.php
@@ -99,7 +99,9 @@ class File extends Field
         /*
          * Make input data validatable if the column data is `null`.
          */
+        /** @phpstan-ignore-next-line Parameter #2 \$key of static method Illuminate\\Support\\Arr::get() expects int|string|null, array|string given. */
         if (Arr::has($input, $this->column) && is_null(Arr::get($input, $this->column))) {
+            /** @phpstan-ignore-next-line Possibly invalid array key type array|string. */
             $input[$this->column] = '';
         }
 
@@ -109,7 +111,9 @@ class File extends Field
             return false;
         }
 
+        /** @phpstan-ignore-next-line Possibly invalid array key type array|string. */
         $rules[$this->column] = $fieldRules;
+        /** @phpstan-ignore-next-line Possibly invalid array key type array|string. */
         $attributes[$this->column] = $this->label;
 
         return \validator($input, $rules, $this->getValidationMessages(), $attributes);
@@ -158,8 +162,10 @@ class File extends Field
         $path = null;
 
         if (!is_null($this->storagePermission)) {
+            /** @phpstan-ignore-next-line Cannot call method putFileAs() on Illuminate\Filesystem\FilesystemAdapter|string. */
             $path = $this->storage->putFileAs($this->getDirectory(), $file, $this->name, $this->storagePermission);
         } else {
+            /** @phpstan-ignore-next-line Cannot call method putFileAs() on Illuminate\Filesystem\FilesystemAdapter|string. */
             $path = $this->storage->putFileAs($this->getDirectory(), $file, $this->name);
         }
 

--- a/src/Form/Field/File.php
+++ b/src/Form/Field/File.php
@@ -262,8 +262,10 @@ class File extends Field
      */
     protected function setupScripts($options)
     {
+        /** @var string $selector */
+        $selector = $this->getElementClassSelector();
         $this->script = <<<EOT
-$("{$this->getElementClassSelector()}").each(function(index, element){
+$("{$selector}").each(function(index, element){
     var options = {$options};
     if(options['initialPreviewConfig'] && options['initialPreviewConfig'].length > 0){
         options['initialPreviewConfig'][0]['caption'] = $(element).data('initial-caption');
@@ -283,7 +285,7 @@ EOT;
             ];
 
             $this->script .= <<<EOT
-$("{$this->getElementClassSelector()}").on('filebeforedelete', function() {
+$("{$selector}").on('filebeforedelete', function() {
     
     return new Promise(function(resolve, reject) {
     
@@ -312,7 +314,7 @@ EOT;
             if(isset($this->options['deletedEvent'])){
                 $deletedEvent = $this->options['deletedEvent'];
                 $this->script .= <<<EOT
-                $("{$this->getElementClassSelector()}").on('filedeleted', function(event, key, jqXHR, data) {
+                $("{$selector}").on('filedeleted', function(event, key, jqXHR, data) {
                     {$deletedEvent};
                 });
 EOT;

--- a/src/Form/Field/HasMany.php
+++ b/src/Form/Field/HasMany.php
@@ -94,10 +94,12 @@ class HasMany extends Field
 
         if (count($arguments) == 1) {
             $this->label = $this->formatLabel();
+            // @phpstan-ignore-next-line Assigned value is always Closure at runtime
             $this->builder = $arguments[0];
         }
 
         if (count($arguments) == 2) {
+            // @phpstan-ignore-next-line Assigned value is always string at runtime (and 1 more mixed-type assumption on this line)
             list($this->label, $this->builder) = $arguments;
         }
     }
@@ -173,6 +175,7 @@ class HasMany extends Field
             $newInput = $input;
         }
 
+        // @phpstan-ignore-next-line $messages is always array at runtime
         return \validator($newInput, $newRules, $this->getValidationMessages(), $attributes);
     }
 
@@ -203,6 +206,7 @@ class HasMany extends Field
             } else {
                 foreach ($new as $k => $val) {
                     if (Str::endsWith($key, ".$k")) {
+                        // @phpstan-ignore-next-line $val is always castable to string at runtime
                         $attributes[$key] = $label."[$val]";
                     }
                 }
@@ -217,6 +221,7 @@ class HasMany extends Field
      * @return $this
      */
     public function setRelatedValue($relatedValue){
+        // @phpstan-ignore-next-line Assigned value is always array|null at runtime
         $this->relatedValue = $relatedValue;
 
         return $this;
@@ -243,6 +248,7 @@ class HasMany extends Field
          *
          * [ "created_at" => "start", "updated_at" => "end" ]
          */
+        // @phpstan-ignore-next-line $array is always array<int|string> at runtime
         $column = array_flip($column);
 
         /**
@@ -258,10 +264,12 @@ class HasMany extends Field
             /*
              * foreach the field set to find the corresponding $column
              */
+            // @phpstan-ignore-next-line The value is always iterable at runtime
             foreach ($set as $name => $value) {
                 /*
                  * if doesn't have column name, continue to the next loop
                  */
+                // @phpstan-ignore-next-line $key is always int|string at runtime
                 if (!array_key_exists($name, $column)) {
                     continue;
                 }
@@ -301,6 +309,7 @@ class HasMany extends Field
         /** @phpstan-ignore-next-line */
         $form = $this->buildNestedForm($this->column, $this->builder);
 
+        // @phpstan-ignore-next-line $data is always array at runtime
         return $form->setOriginal($this->original, $this->getKeyName())->prepare($input);
     }
 
@@ -316,6 +325,7 @@ class HasMany extends Field
         /** @phpstan-ignore-next-line */
         $form = $this->buildNestedForm($this->column, $this->builder);
 
+        // @phpstan-ignore-next-line $data is always array at runtime
         return $form->setOriginal($this->original, $this->getKeyName())->prepareConfirm($input);
     }
 
@@ -331,7 +341,6 @@ class HasMany extends Field
 
         foreach ($form->fields() as $field) {
             if(method_exists($field, 'hasFile')){
-                /** @phpstan-ignore-next-line Cannot call method hasFile() on class-string|object. */
                 if($field->hasFile()){
                     return true;
                 }
@@ -457,6 +466,7 @@ class HasMany extends Field
             foreach ($this->relatedValue as $index => $data) {
                 /** @phpstan-ignore-next-line */
                 $forms[$index] = $this->buildNestedForm($this->column, $this->builder, null, $index)
+                    // @phpstan-ignore-next-line $data is always array at runtime
                     ->fill($data, $index);
             }
         }
@@ -484,7 +494,9 @@ class HasMany extends Field
         /** @phpstan-ignore-next-line */
         if ($values = old($this->column)) {
             $index = 0;
+            // @phpstan-ignore-next-line The value is always iterable at runtime
             foreach ($values as $key => $data) {
+                // @phpstan-ignore-next-line The value is always an array at runtime
                 if ($data[NestedForm::REMOVE_FLAG_NAME] == 1) {
                     $index++;
                     continue;
@@ -495,11 +507,14 @@ class HasMany extends Field
                     $forms = [];
                 }
                 
+                // @phpstan-ignore-next-line $attributes is always array at runtime
                 $model = $relation->getRelated()->replicate()->forceFill($data);
 
                 $formIndex = $index;
                 // if new_ key, 
+                // @phpstan-ignore-next-line $haystack is always string at runtime
                 if(strpos($key, 'new_') !== false){
+                    // @phpstan-ignore-next-line $subject is always array|string at runtime
                     $formIndex = str_replace('new_', '', $key);
                 }
                 /** @phpstan-ignore-next-line */
@@ -511,6 +526,7 @@ class HasMany extends Field
         } else {
             // @phpstan-ignore-next-line Value is guaranteed to be iterable at this point
             foreach ($this->value as $index => $data) {
+                // @phpstan-ignore-next-line $array is always array|ArrayAccess at runtime
                 $key = Arr::get($data, $relation->getRelated()->getKeyName());
 
                 if(!isset($key)){
@@ -522,11 +538,13 @@ class HasMany extends Field
                     $forms = [];
                 }
                 
+                // @phpstan-ignore-next-line $attributes is always array at runtime
                 $model = $relation->getRelated()->replicate()->forceFill($data);
 
                 /** @var int $index */
                 /** @phpstan-ignore-next-line */
                 $forms[$key] = $this->buildNestedForm($this->column, $this->builder, $model, $index)
+                    // @phpstan-ignore-next-line $data is always array at runtime
                     ->fill($data, $index);
             }
         }

--- a/src/Form/Field/HasMany.php
+++ b/src/Form/Field/HasMany.php
@@ -561,8 +561,11 @@ class HasMany extends Field
         $removeClass = NestedForm::REMOVE_FLAG_CLASS;
         $defaultKey = NestedForm::DEFAULT_KEY_NAME;
         $count = !isset($this->value) ? 0 : count($this->value);
-        /** @phpstan-ignore-next-line Part $this->column (array|string) of encapsed string cannot be cast to string. */
-        $indexName = "index_{$this->column}";
+        
+        // Maintain original behavior - column will be cast to string
+        /** @phpstan-ignore-next-line */
+        $columnName = (string) $this->column;
+        $indexName = "index_{$columnName}";
 
         /**
          * When add a new sub form, replace all element key in new sub form.
@@ -573,21 +576,21 @@ class HasMany extends Field
          */
         $script = <<<EOT
 var index = 0;
-$('#has-many-{$this->column}').off('click.admin_add', '.add').on('click.admin_add', '.add', function () {
+$('#has-many-{$columnName}').off('click.admin_add', '.add').on('click.admin_add', '.add', function () {
 
-    var tpl = $('template.{$this->column}-tpl');
+    var tpl = $('template.{$columnName}-tpl');
 
     $indexName++;
 
     var template = tpl.html().replace(/{$defaultKey}/g, $indexName);
-    $('.has-many-{$this->column}-forms').append(template);
+    $('.has-many-{$columnName}-forms').append(template);
     {$templateScript}
     return false;
 });
 
-$('#has-many-{$this->column}').off('click.admin_remove', '.remove').on('click.admin_remove', '.remove', function () {
-    $(this).closest('.has-many-{$this->column}-form').hide();
-    $(this).closest('.has-many-{$this->column}-form').find('.$removeClass').val(1);
+$('#has-many-{$columnName}').off('click.admin_remove', '.remove').on('click.admin_remove', '.remove', function () {
+    $(this).closest('.has-many-{$columnName}-form').hide();
+    $(this).closest('.has-many-{$columnName}-form').find('.$removeClass').val(1);
     return false;
 });
 
@@ -608,10 +611,14 @@ EOT;
         $removeClass = NestedForm::REMOVE_FLAG_CLASS;
         $defaultKey = NestedForm::DEFAULT_KEY_NAME;
         $count = !isset($this->value) ? 0 : count($this->value);
+        
+        // Maintain original behavior - column will be cast to string
+        /** @phpstan-ignore-next-line */
+        $columnName = (string) $this->column;
 
         $script = <<<EOT
 
-$('#has-many-{$this->column} > .nav').off('click', 'i.close-tab').on('click', 'i.close-tab', function(){
+$('#has-many-{$columnName} > .nav').off('click', 'i.close-tab').on('click', 'i.close-tab', function(){
     var \$navTab = $(this).siblings('a');
     var \$pane = $(\$navTab.attr('href'));
     if( \$pane.hasClass('new') ){
@@ -621,20 +628,20 @@ $('#has-many-{$this->column} > .nav').off('click', 'i.close-tab').on('click', 'i
     }
     if(\$navTab.closest('li').hasClass('active')){
         \$navTab.closest('li').remove();
-        $('#has-many-{$this->column} > .nav > li:nth-child(1) > a').tab('show');
+        $('#has-many-{$columnName} > .nav > li:nth-child(1) > a').tab('show');
     }else{
         \$navTab.closest('li').remove();
     }
 });
 
 var index = {$count};
-$('#has-many-{$this->column} > .header').off('click', '.add').on('click', '.add', function(){
+$('#has-many-{$columnName} > .header').off('click', '.add').on('click', '.add', function(){
     index++;
-    var navTabHtml = $('#has-many-{$this->column} > template.nav-tab-tpl').html().replace(/{$defaultKey}/g, index);
-    var paneHtml = $('#has-many-{$this->column} > template.pane-tpl').html().replace(/{$defaultKey}/g, index);
-    $('#has-many-{$this->column} > .nav').append(navTabHtml);
-    $('#has-many-{$this->column} > .tab-content').append(paneHtml);
-    $('#has-many-{$this->column} > .nav > li:last-child a').tab('show');
+    var navTabHtml = $('#has-many-{$columnName} > template.nav-tab-tpl').html().replace(/{$defaultKey}/g, index);
+    var paneHtml = $('#has-many-{$columnName} > template.pane-tpl').html().replace(/{$defaultKey}/g, index);
+    $('#has-many-{$columnName} > .nav').append(navTabHtml);
+    $('#has-many-{$columnName} > .tab-content').append(paneHtml);
+    $('#has-many-{$columnName} > .nav > li:last-child a').tab('show');
     {$templateScript}
 });
 
@@ -663,6 +670,10 @@ EOT;
     {
         $removeClass = NestedForm::REMOVE_FLAG_CLASS;
         $defaultKey = NestedForm::DEFAULT_KEY_NAME;
+        
+        // Maintain original behavior - column will be cast to string
+        /** @phpstan-ignore-next-line */
+        $columnName = (string) $this->column;
 
         /**
          * When add a new sub form, replace all element key in new sub form.
@@ -673,21 +684,21 @@ EOT;
          */
         $script = <<<EOT
 var index = 0;
-$('#has-many-{$this->column}').off('click.admin_add').on('click.admin_add', '.add', function () {
+$('#has-many-{$columnName}').off('click.admin_add').on('click.admin_add', '.add', function () {
 
-    var tpl = $('template.{$this->column}-tpl');
+    var tpl = $('template.{$columnName}-tpl');
 
     index++;
 
     var template = tpl.html().replace(/{$defaultKey}/g, index);
-    $('.has-many-{$this->column}-forms').append(template);
+    $('.has-many-{$columnName}-forms').append(template);
     {$templateScript}
     return false;
 });
 
-$('#has-many-{$this->column}').off('click.admin_remove').on('click.admin_remove', '.remove', function () {
-    $(this).closest('.has-many-{$this->column}-form').hide();
-    $(this).closest('.has-many-{$this->column}-form').find('.$removeClass').val(1);
+$('#has-many-{$columnName}').off('click.admin_remove').on('click.admin_remove', '.remove', function () {
+    $(this).closest('.has-many-{$columnName}-form').hide();
+    $(this).closest('.has-many-{$columnName}-form').find('.$removeClass').val(1);
     return false;
 });
 
@@ -734,6 +745,7 @@ EOT;
         // specify a view to render.
         $this->view = $this->views[$this->viewMode];
 
+        /** @phpstan-ignore-next-line Parameter #1 $column of method Encore\Admin\Form\Field\HasMany::buildNestedForm() expects string, array|string given. */
         list($template, $script) = $this->buildNestedForm($this->column, $this->builder)
             ->getTemplateHtmlAndScript();
 
@@ -760,6 +772,7 @@ EOT;
         $scripts = [];
 
         /* @var Field $field */
+        /** @phpstan-ignore-next-line Parameter #1 $column of method Encore\Admin\Form\Field\HasMany::buildNestedForm() expects string, array|string given. */
         foreach ($this->buildNestedForm($this->column, $this->builder)->fields() as $field) {
             if (is_a($field, Hidden::class)) {
                 $hidden[] = $field->render();

--- a/src/Form/Field/HasMany.php
+++ b/src/Form/Field/HasMany.php
@@ -111,6 +111,7 @@ class HasMany extends Field
      */
     public function getValidator(array $input)
     {
+        /** @phpstan-ignore-next-line */
         if (!array_key_exists($this->column, $input)) {
             return false;
         }
@@ -156,10 +157,12 @@ class HasMany extends Field
 
         foreach ($rules as $column => $rule) {
             foreach (array_keys($input[$this->column]) as $key) {
+                /** @phpstan-ignore-next-line */
                 $newRules["{$this->column}.$key.$column"] = $rule;
                 if (isset($input[$this->column][$key][$column]) &&
                     is_array($input[$this->column][$key][$column])) {
                     foreach ($input[$this->column][$key][$column] as $vkey => $value) {
+                        /** @phpstan-ignore-next-line */
                         $newInput["{$this->column}.$key.{$column}$vkey"] = $value;
                     }
                 }
@@ -249,6 +252,7 @@ class HasMany extends Field
          *
          * in the HasMany relation, has many data/field set, $set is field set in the below
          */
+        /** @phpstan-ignore-next-line */
         foreach ($input[$this->column] as $index => $set) {
 
             /*
@@ -274,10 +278,12 @@ class HasMany extends Field
                 /*
                  * set new key
                  */
+                /** @phpstan-ignore-next-line */
                 Arr::set($input, "{$this->column}.$index.$newKey", $value);
                 /*
                  * forget the old key and value
                  */
+                /** @phpstan-ignore-next-line */
                 Arr::forget($input, "{$this->column}.$index.$name");
             }
         }
@@ -292,6 +298,7 @@ class HasMany extends Field
      */
     public function prepare($input)
     {
+        /** @phpstan-ignore-next-line */
         $form = $this->buildNestedForm($this->column, $this->builder);
 
         return $form->setOriginal($this->original, $this->getKeyName())->prepare($input);
@@ -306,6 +313,7 @@ class HasMany extends Field
      */
     public function prepareConfirm($input)
     {
+        /** @phpstan-ignore-next-line */
         $form = $this->buildNestedForm($this->column, $this->builder);
 
         return $form->setOriginal($this->original, $this->getKeyName())->prepareConfirm($input);
@@ -318,10 +326,12 @@ class HasMany extends Field
      */
     public function hasFile()
     {
+        /** @phpstan-ignore-next-line */
         $form = $this->buildNestedForm($this->column, $this->builder);
 
         foreach ($form->fields() as $field) {
             if(method_exists($field, 'hasFile')){
+                /** @phpstan-ignore-next-line Cannot call method hasFile() on class-string|object. */
                 if($field->hasFile()){
                     return true;
                 }
@@ -445,6 +455,7 @@ class HasMany extends Field
 
         if(!is_null($this->relatedValue)){
             foreach ($this->relatedValue as $index => $data) {
+                /** @phpstan-ignore-next-line */
                 $forms[$index] = $this->buildNestedForm($this->column, $this->builder, null, $index)
                     ->fill($data, $index);
             }
@@ -456,6 +467,7 @@ class HasMany extends Field
 
         $model = $this->form->model();
 
+        /** @phpstan-ignore-next-line Parameter #1 $callback of function call_user_func expects callable(): mixed, array{Illuminate\Database\Eloquent\Model, string} given. */
         $relation = call_user_func([$model, $this->relationName]);
 
         if (!$relation instanceof Relation && !$relation instanceof MorphMany) {
@@ -469,6 +481,7 @@ class HasMany extends Field
          *
          * Else get data from database.
          */
+        /** @phpstan-ignore-next-line */
         if ($values = old($this->column)) {
             $index = 0;
             foreach ($values as $key => $data) {
@@ -489,7 +502,9 @@ class HasMany extends Field
                 if(strpos($key, 'new_') !== false){
                     $formIndex = str_replace('new_', '', $key);
                 }
+                /** @phpstan-ignore-next-line */
                 $forms[$key] = $this->buildNestedForm($this->column, $this->builder, $model, $formIndex)
+                    /** @phpstan-ignore-next-line */
                     ->fill($data, $formIndex);
                     $index++;
             }
@@ -508,6 +523,8 @@ class HasMany extends Field
                 
                 $model = $relation->getRelated()->replicate()->forceFill($data);
 
+                /** @var int $index */
+                /** @phpstan-ignore-next-line */
                 $forms[$key] = $this->buildNestedForm($this->column, $this->builder, $model, $index)
                     ->fill($data, $index);
             }
@@ -525,8 +542,10 @@ class HasMany extends Field
      */
     protected function setupScript($script)
     {
+        /** @var string $method */
         $method = 'setupScriptFor'.ucfirst($this->viewMode).'View';
 
+        /** @phpstan-ignore-next-line Parameter #1 $callback of function call_user_func expects callable(): mixed, array{$this(Encore\Admin\Form\Field\HasMany), non-falsy-string} given. */
         return call_user_func([$this, $method], $script);
     }
 
@@ -551,6 +570,7 @@ class HasMany extends Field
          *
          * {count} is increment number of current sub form count.
          */
+        /** @phpstan-ignore-next-line argument.type */
         $script = <<<EOT
 var index = 0;
 $('#has-many-{$this->column}').off('click.admin_add', '.add').on('click.admin_add', '.add', function () {
@@ -589,6 +609,7 @@ EOT;
         $defaultKey = NestedForm::DEFAULT_KEY_NAME;
         $count = !isset($this->value) ? 0 : count($this->value);
 
+        /** @phpstan-ignore-next-line argument.type */
         $script = <<<EOT
 
 $('#has-many-{$this->column} > .nav').off('click', 'i.close-tab').on('click', 'i.close-tab', function(){
@@ -653,6 +674,7 @@ EOT;
          */
         $script = <<<EOT
 var index = 0;
+/** @phpstan-ignore-next-line argument.type */
 $('#has-many-{$this->column}').off('click.admin_add').on('click.admin_add', '.add', function () {
 
     var tpl = $('template.{$this->column}-tpl');
@@ -660,13 +682,17 @@ $('#has-many-{$this->column}').off('click.admin_add').on('click.admin_add', '.ad
     index++;
 
     var template = tpl.html().replace(/{$defaultKey}/g, index);
+    /** @phpstan-ignore-next-line argument.type */
     $('.has-many-{$this->column}-forms').append(template);
     {$templateScript}
     return false;
 });
 
+/** @phpstan-ignore-next-line argument.type */
 $('#has-many-{$this->column}').off('click.admin_remove').on('click.admin_remove', '.remove', function () {
+    /** @phpstan-ignore-next-line argument.type */
     $(this).closest('.has-many-{$this->column}-form').hide();
+    /** @phpstan-ignore-next-line argument.type */
     $(this).closest('.has-many-{$this->column}-form').find('.$removeClass').val(1);
     return false;
 });

--- a/src/Form/Field/HasMany.php
+++ b/src/Form/Field/HasMany.php
@@ -561,6 +561,7 @@ class HasMany extends Field
         $removeClass = NestedForm::REMOVE_FLAG_CLASS;
         $defaultKey = NestedForm::DEFAULT_KEY_NAME;
         $count = !isset($this->value) ? 0 : count($this->value);
+        /** @phpstan-ignore-next-line Part $this->column (array|string) of encapsed string cannot be cast to string. */
         $indexName = "index_{$this->column}";
 
         /**
@@ -570,7 +571,7 @@ class HasMany extends Field
          *
          * {count} is increment number of current sub form count.
          */
-        /** @phpstan-ignore-next-line argument.type */
+        /** @phpstan-ignore-next-line Part $this->column (array|string) of encapsed string cannot be cast to string. */
         $script = <<<EOT
 var index = 0;
 $('#has-many-{$this->column}').off('click.admin_add', '.add').on('click.admin_add', '.add', function () {
@@ -609,7 +610,7 @@ EOT;
         $defaultKey = NestedForm::DEFAULT_KEY_NAME;
         $count = !isset($this->value) ? 0 : count($this->value);
 
-        /** @phpstan-ignore-next-line argument.type */
+        /** @phpstan-ignore-next-line Part $this->column (array|string) of encapsed string cannot be cast to string. */
         $script = <<<EOT
 
 $('#has-many-{$this->column} > .nav').off('click', 'i.close-tab').on('click', 'i.close-tab', function(){
@@ -674,7 +675,6 @@ EOT;
          */
         $script = <<<EOT
 var index = 0;
-/** @phpstan-ignore-next-line argument.type */
 $('#has-many-{$this->column}').off('click.admin_add').on('click.admin_add', '.add', function () {
 
     var tpl = $('template.{$this->column}-tpl');
@@ -682,17 +682,13 @@ $('#has-many-{$this->column}').off('click.admin_add').on('click.admin_add', '.ad
     index++;
 
     var template = tpl.html().replace(/{$defaultKey}/g, index);
-    /** @phpstan-ignore-next-line argument.type */
     $('.has-many-{$this->column}-forms').append(template);
     {$templateScript}
     return false;
 });
 
-/** @phpstan-ignore-next-line argument.type */
 $('#has-many-{$this->column}').off('click.admin_remove').on('click.admin_remove', '.remove', function () {
-    /** @phpstan-ignore-next-line argument.type */
     $(this).closest('.has-many-{$this->column}-form').hide();
-    /** @phpstan-ignore-next-line argument.type */
     $(this).closest('.has-many-{$this->column}-form').find('.$removeClass').val(1);
     return false;
 });
@@ -740,6 +736,7 @@ EOT;
         // specify a view to render.
         $this->view = $this->views[$this->viewMode];
 
+        /** @phpstan-ignore-next-line Parameter #1 $column of method Encore\Admin\Form\Field\HasMany::buildNestedForm() expects string, array|string given. */
         list($template, $script) = $this->buildNestedForm($this->column, $this->builder)
             ->getTemplateHtmlAndScript();
 
@@ -766,6 +763,7 @@ EOT;
         $scripts = [];
 
         /* @var Field $field */
+        /** @phpstan-ignore-next-line Parameter #1 $column of method Encore\Admin\Form\Field\HasMany::buildNestedForm() expects string, array|string given. */
         foreach ($this->buildNestedForm($this->column, $this->builder)->fields() as $field) {
             if (is_a($field, Hidden::class)) {
                 $hidden[] = $field->render();

--- a/src/Form/Field/HasMany.php
+++ b/src/Form/Field/HasMany.php
@@ -509,6 +509,7 @@ class HasMany extends Field
                     $index++;
             }
         } else {
+            // @phpstan-ignore-next-line Value is guaranteed to be iterable at this point
             foreach ($this->value as $index => $data) {
                 $key = Arr::get($data, $relation->getRelated()->getKeyName());
 

--- a/src/Form/Field/HasMany.php
+++ b/src/Form/Field/HasMany.php
@@ -157,12 +157,12 @@ class HasMany extends Field
 
         foreach ($rules as $column => $rule) {
             foreach (array_keys($input[$this->column]) as $key) {
-                /** @phpstan-ignore-next-line */
+                /** @phpstan-ignore-next-line Part $this->column (array|string) of encapsed string cannot be cast to string. */
                 $newRules["{$this->column}.$key.$column"] = $rule;
                 if (isset($input[$this->column][$key][$column]) &&
                     is_array($input[$this->column][$key][$column])) {
                     foreach ($input[$this->column][$key][$column] as $vkey => $value) {
-                        /** @phpstan-ignore-next-line */
+                        /** @phpstan-ignore-next-line Part $this->column (array|string) of encapsed string cannot be cast to string. */
                         $newInput["{$this->column}.$key.{$column}$vkey"] = $value;
                     }
                 }
@@ -278,12 +278,12 @@ class HasMany extends Field
                 /*
                  * set new key
                  */
-                /** @phpstan-ignore-next-line */
+                /** @phpstan-ignore-next-line Part $this->column (array|string) of encapsed string cannot be cast to string. */
                 Arr::set($input, "{$this->column}.$index.$newKey", $value);
                 /*
                  * forget the old key and value
                  */
-                /** @phpstan-ignore-next-line */
+                /** @phpstan-ignore-next-line Part $this->column (array|string) of encapsed string cannot be cast to string. */
                 Arr::forget($input, "{$this->column}.$index.$name");
             }
         }
@@ -571,7 +571,6 @@ class HasMany extends Field
          *
          * {count} is increment number of current sub form count.
          */
-        /** @phpstan-ignore-next-line Part $this->column (array|string) of encapsed string cannot be cast to string. */
         $script = <<<EOT
 var index = 0;
 $('#has-many-{$this->column}').off('click.admin_add', '.add').on('click.admin_add', '.add', function () {
@@ -610,7 +609,6 @@ EOT;
         $defaultKey = NestedForm::DEFAULT_KEY_NAME;
         $count = !isset($this->value) ? 0 : count($this->value);
 
-        /** @phpstan-ignore-next-line Part $this->column (array|string) of encapsed string cannot be cast to string. */
         $script = <<<EOT
 
 $('#has-many-{$this->column} > .nav').off('click', 'i.close-tab').on('click', 'i.close-tab', function(){
@@ -736,7 +734,6 @@ EOT;
         // specify a view to render.
         $this->view = $this->views[$this->viewMode];
 
-        /** @phpstan-ignore-next-line Parameter #1 $column of method Encore\Admin\Form\Field\HasMany::buildNestedForm() expects string, array|string given. */
         list($template, $script) = $this->buildNestedForm($this->column, $this->builder)
             ->getTemplateHtmlAndScript();
 
@@ -763,7 +760,6 @@ EOT;
         $scripts = [];
 
         /* @var Field $field */
-        /** @phpstan-ignore-next-line Parameter #1 $column of method Encore\Admin\Form\Field\HasMany::buildNestedForm() expects string, array|string given. */
         foreach ($this->buildNestedForm($this->column, $this->builder)->fields() as $field) {
             if (is_a($field, Hidden::class)) {
                 $hidden[] = $field->render();

--- a/src/Form/Field/Html.php
+++ b/src/Form/Field/Html.php
@@ -55,6 +55,7 @@ class Html extends Field
     public function render()
     {
         if ($this->html instanceof \Closure) {
+            // @phpstan-ignore-next-line Form and Model are guaranteed to be set during render
             $this->html = $this->html->call($this->form->model(), $this->form);
         }
 

--- a/src/Form/Field/Html.php
+++ b/src/Form/Field/Html.php
@@ -32,8 +32,10 @@ class Html extends Field
      */
     public function __construct($html, $arguments)
     {
+        // @phpstan-ignore-next-line Assigned value is always Closure|string at runtime
         $this->html = $html;
 
+        // @phpstan-ignore-next-line Assigned value is always string at runtime
         $this->label = Arr::get($arguments, 0);
     }
 
@@ -60,16 +62,21 @@ class Html extends Field
         }
 
         if ($this->plain) {
+            // @phpstan-ignore-next-line Return value is always string at runtime
             return $this->html;
         }
 
         $viewClass = $this->getViewElementClasses();
 
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var string $html */
+        $html = $this->html;
+
         return <<<EOT
 <div class="form-group">
     <label  class="{$viewClass['label']} control-label">{$this->label}</label>
     <div class="{$viewClass['field']}">
-        {$this->html}
+        {$html}
     </div>
 </div>
 EOT;

--- a/src/Form/Field/Icon.php
+++ b/src/Form/Field/Icon.php
@@ -28,7 +28,6 @@ class Icon extends Text
      */
     public function render()
     {
-        /** @phpstan-ignore-next-line argument.type */
         $this->script = <<<EOT
 
 $('{$this->getElementClassSelector()}').iconpicker({placement:'bottomLeft'});

--- a/src/Form/Field/Icon.php
+++ b/src/Form/Field/Icon.php
@@ -28,6 +28,7 @@ class Icon extends Text
      */
     public function render()
     {
+        /** @phpstan-ignore-next-line argument.type */
         $this->script = <<<EOT
 
 $('{$this->getElementClassSelector()}').iconpicker({placement:'bottomLeft'});

--- a/src/Form/Field/Icon.php
+++ b/src/Form/Field/Icon.php
@@ -28,10 +28,11 @@ class Icon extends Text
      */
     public function render()
     {
-        /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
+        /** @var string $selector */
+        $selector = $this->getElementClassSelector();
         $this->script = <<<EOT
 
-$('{$this->getElementClassSelector()}').iconpicker({placement:'bottomLeft'});
+$('{$selector}').iconpicker({placement:'bottomLeft'});
 
 EOT;
 

--- a/src/Form/Field/Icon.php
+++ b/src/Form/Field/Icon.php
@@ -28,6 +28,7 @@ class Icon extends Text
      */
     public function render()
     {
+        /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
         $this->script = <<<EOT
 
 $('{$this->getElementClassSelector()}').iconpicker({placement:'bottomLeft'});

--- a/src/Form/Field/ImageField.php
+++ b/src/Form/Field/ImageField.php
@@ -48,10 +48,12 @@ trait ImageField
 
             foreach ($this->interventionCalls as $call) {
                 /** @var callable $callable */
+                // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
                 $callable = [$image, $call['method']];
                 /** @var \Intervention\Image\Image $result */
                 $result = call_user_func_array(
                     $callable,
+                    // @phpstan-ignore-next-line The value is always an array at runtime (and 3 more mixed-type assumptions on this line)
                     $call['arguments']
                 );
                 $result->save($target);
@@ -110,6 +112,7 @@ trait ImageField
     {
         if (func_num_args() == 1 && is_array($name)) {
             foreach ($name as $key => $size) {
+                // @phpstan-ignore-next-line $value is always array|Countable at runtime (and 1 more mixed-type assumption on this line)
                 if (count($size) == 2) {
                     $this->thumbnails[$key] = $size;
                 }
@@ -135,9 +138,11 @@ trait ImageField
 
         foreach ($this->thumbnails as $name => $_) {
             // We need to get extension type ( .jpeg , .png ...)
+            // @phpstan-ignore-next-line $path is always string at runtime (and 1 more mixed-type assumption on this line)
             $ext = pathinfo($this->original, PATHINFO_EXTENSION);
 
             // We remove extension from file name so we can append thumbnail type
+            // @phpstan-ignore-next-line $subject is always string at runtime (and 1 more mixed-type assumption on this line)
             $path = Str::replaceLast('.'.$ext, '', $this->original);
 
             // We merge original name + thumbnail name + extension
@@ -162,9 +167,11 @@ trait ImageField
     {
         foreach ($this->thumbnails as $name => $size) {
             // We need to get extension type ( .jpeg , .png ...)
+            // @phpstan-ignore-next-line $path is always string at runtime (and 1 more mixed-type assumption on this line)
             $ext = pathinfo($this->name, PATHINFO_EXTENSION);
 
             // We remove extension from file name so we can append thumbnail type
+            // @phpstan-ignore-next-line $subject is always string at runtime (and 1 more mixed-type assumption on this line)
             $path = Str::replaceLast('.'.$ext, '', $this->name);
 
             // We merge original name + thumbnail name + extension
@@ -174,8 +181,10 @@ trait ImageField
             $image = InterventionImage::make($file);
 
             // Resize image with aspect ratio
+            // @phpstan-ignore-next-line The value is always an array at runtime (and 7 more mixed-type assumptions on this line)
             $image->resize($size[0], $size[1], function (Constraint $constraint) {
                 $constraint->aspectRatio();
+            // @phpstan-ignore-next-line The value is always an array at runtime (and 7 more mixed-type assumptions on this line)
             })->resizeCanvas($size[0], $size[1], 'center', false, '#ffffff');
 
             if (!is_null($this->storagePermission)) {

--- a/src/Form/Field/ImageField.php
+++ b/src/Form/Field/ImageField.php
@@ -47,6 +47,7 @@ trait ImageField
             $image = ImageManagerStatic::make($target);
 
             foreach ($this->interventionCalls as $call) {
+                /** @phpstan-ignore-next-line argument.type */
                 call_user_func_array(
                     [$image, $call['method']],
                     $call['arguments']

--- a/src/Form/Field/ImageField.php
+++ b/src/Form/Field/ImageField.php
@@ -47,11 +47,14 @@ trait ImageField
             $image = ImageManagerStatic::make($target);
 
             foreach ($this->interventionCalls as $call) {
-                /** @phpstan-ignore-next-line argument.type */
-                call_user_func_array(
-                    [$image, $call['method']],
+                /** @var callable $callable */
+                $callable = [$image, $call['method']];
+                /** @var \Intervention\Image\Image $result */
+                $result = call_user_func_array(
+                    $callable,
                     $call['arguments']
-                )->save($target);
+                );
+                $result->save($target);
             }
         }
 
@@ -112,6 +115,7 @@ trait ImageField
                 }
             }
         } elseif (func_num_args() == 3) {
+            /** @phpstan-ignore-next-line Possibly invalid array key type array|string. */
             $this->thumbnails[$name] = [$width, $height];
         }
 
@@ -139,7 +143,9 @@ trait ImageField
             // We merge original name + thumbnail name + extension
             $path = $path.'-'.$name.'.'.$ext;
 
+            /** @phpstan-ignore-next-line Cannot call method exists() on Illuminate\Filesystem\FilesystemAdapter|string. */
             if ($this->storage->exists($path)) {
+                /** @phpstan-ignore-next-line Cannot call method delete() on Illuminate\Filesystem\FilesystemAdapter|string. */
                 $this->storage->delete($path);
             }
         }
@@ -173,8 +179,10 @@ trait ImageField
             })->resizeCanvas($size[0], $size[1], 'center', false, '#ffffff');
 
             if (!is_null($this->storagePermission)) {
+                /** @phpstan-ignore-next-line Cannot call method put() on Illuminate\Filesystem\FilesystemAdapter|string. */
                 $this->storage->put("{$this->getDirectory()}/{$path}", $image->encode(), $this->storagePermission);
             } else {
+                /** @phpstan-ignore-next-line Cannot call method put() on Illuminate\Filesystem\FilesystemAdapter|string. */
                 $this->storage->put("{$this->getDirectory()}/{$path}", $image->encode());
             }
         }

--- a/src/Form/Field/KeyValue.php
+++ b/src/Form/Field/KeyValue.php
@@ -70,15 +70,18 @@ class KeyValue extends Field
      */
     protected function setupScript()
     {
-        /** @phpstan-ignore-next-line Part $this->column (array|string) of encapsed string cannot be cast to string. */
+        // Maintain original behavior - column will be cast to string
+        /** @phpstan-ignore-next-line */
+        $columnName = (string) $this->column;
+        
         $this->script = <<<SCRIPT
 
-$('.{$this->column}-add').on('click', function () {
-    var tpl = $('template.{$this->column}-tpl').html();
-    $('tbody.kv-{$this->column}-table').append(tpl);
+$('.{$columnName}-add').on('click', function () {
+    var tpl = $('template.{$columnName}-tpl').html();
+    $('tbody.kv-{$columnName}-table').append(tpl);
 });
 
-$('tbody').on('click', '.{$this->column}-remove', function () {
+$('tbody').on('click', '.{$columnName}-remove', function () {
     $(this).closest('tr').remove();
 });
 

--- a/src/Form/Field/KeyValue.php
+++ b/src/Form/Field/KeyValue.php
@@ -26,6 +26,7 @@ class KeyValue extends Field
     {
         $this->data = $data;
 
+        /** @phpstan-ignore-next-line Parameter #2 $key of static method Illuminate\Support\Arr::get() expects int|string|null, array|string given. */
         $this->value = Arr::get($data, $this->column, $this->value);
 
         $this->formatValue();
@@ -69,6 +70,7 @@ class KeyValue extends Field
      */
     protected function setupScript()
     {
+        /** @phpstan-ignore-next-line Part $this->column (array|string) of encapsed string cannot be cast to string. */
         $this->script = <<<SCRIPT
 
 $('.{$this->column}-add').on('click', function () {

--- a/src/Form/Field/KeyValue.php
+++ b/src/Form/Field/KeyValue.php
@@ -70,7 +70,6 @@ class KeyValue extends Field
      */
     protected function setupScript()
     {
-        /** @phpstan-ignore-next-line Part $this->column (array|string) of encapsed string cannot be cast to string. */
         $this->script = <<<SCRIPT
 
 $('.{$this->column}-add').on('click', function () {

--- a/src/Form/Field/KeyValue.php
+++ b/src/Form/Field/KeyValue.php
@@ -70,6 +70,7 @@ class KeyValue extends Field
      */
     protected function setupScript()
     {
+        /** @phpstan-ignore-next-line Part $this->column (array|string) of encapsed string cannot be cast to string. */
         $this->script = <<<SCRIPT
 
 $('.{$this->column}-add').on('click', function () {

--- a/src/Form/Field/KeyValue.php
+++ b/src/Form/Field/KeyValue.php
@@ -40,6 +40,7 @@ class KeyValue extends Field
     public function getValidator(array $input)
     {
         if ($this->validator) {
+            // @phpstan-ignore-next-line Return value is always bool|Illuminate\Contracts\Validation\Factory|Illuminate\Contracts\Validation\Validator at runtime
             return $this->validator->call($this, $input);
         }
 
@@ -62,6 +63,7 @@ class KeyValue extends Field
         $attributes["{$this->column}.keys.*"] = __('Key');
         $attributes["{$this->column}.values.*"] = __('Value');
 
+        // @phpstan-ignore-next-line $messages is always array at runtime
         return validator($input, $rules, $this->getValidationMessages(), $attributes);
     }
 
@@ -94,6 +96,7 @@ SCRIPT;
      */
     public function prepare($value)
     {
+        // @phpstan-ignore-next-line $keys is always array<int|string> at runtime (and 1 more mixed-type assumption on this line)
         return array_combine($value['keys'], $value['values']);
     }
 

--- a/src/Form/Field/ListField.php
+++ b/src/Form/Field/ListField.php
@@ -66,6 +66,7 @@ class ListField extends Field
     {
         $this->data = $data;
 
+        /** @phpstan-ignore-next-line Parameter #2 $key of static method Illuminate\Support\Arr::get() expects int|string|null, array|string given. */
         $this->value = Arr::get($data, $this->column, $this->value);
 
         $this->formatValue();
@@ -99,6 +100,7 @@ class ListField extends Field
         $rules["{$this->column}.values.*"] = $fieldRules;
         $attributes["{$this->column}.values.*"] = __('Value');
 
+        /** @phpstan-ignore-next-line Cannot access an offset on array|Closure|string. */
         $rules["{$this->column}.values"][] = 'array';
 
         if (!is_null($this->max)) {

--- a/src/Form/Field/ListField.php
+++ b/src/Form/Field/ListField.php
@@ -80,6 +80,7 @@ class ListField extends Field
     public function getValidator(array $input)
     {
         if ($this->validator) {
+            // @phpstan-ignore-next-line Return value is always bool|Illuminate\Contracts\Validation\Validator at runtime
             return $this->validator->call($this, $input);
         }
 
@@ -113,6 +114,7 @@ class ListField extends Field
 
         $attributes["{$this->column}.values"] = $this->label;
 
+        // @phpstan-ignore-next-line $messages is always array at runtime
         return validator($input, $rules, $this->getValidationMessages(), $attributes);
     }
 
@@ -147,6 +149,7 @@ SCRIPT;
      */
     public function prepare($value)
     {
+        // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
         return array_values($value['values']);
     }
 

--- a/src/Form/Field/ListField.php
+++ b/src/Form/Field/ListField.php
@@ -122,14 +122,18 @@ class ListField extends Field
      */
     protected function setupScript()
     {
+        // Maintain original behavior - column will be cast to string
+        /** @phpstan-ignore-next-line */
+        $columnName = (string) $this->column;
+        
         $this->script = <<<SCRIPT
 
-$('.{$this->column}-add').on('click', function () {
-    var tpl = $('template.{$this->column}-tpl').html();
-    $('tbody.list-{$this->column}-table').append(tpl);
+$('.{$columnName}-add').on('click', function () {
+    var tpl = $('template.{$columnName}-tpl').html();
+    $('tbody.list-{$columnName}-table').append(tpl);
 });
 
-$('tbody').on('click', '.{$this->column}-remove', function () {
+$('tbody').on('click', '.{$columnName}-remove', function () {
     $(this).closest('tr').remove();
 });
 

--- a/src/Form/Field/Listbox.php
+++ b/src/Form/Field/Listbox.php
@@ -64,11 +64,15 @@ class Listbox extends MultipleSelect
             'url' => $url.'?'.http_build_query($parameters),
         ], $options));
 
+        // Ensure selector is string for heredoc usage
+        $selector = $this->getElementClassSelector();
+        $selectorString = is_array($selector) ? implode(',', $selector) : (string) $selector;
+        
         $this->script = <<<EOT
         
 $.ajax($ajaxOptions).done(function(data) {
 
-  var listbox = $("{$this->getElementClassSelector()}");
+  var listbox = $("{$selectorString}");
 
     var value = listbox.data('value') + '';
     
@@ -105,9 +109,13 @@ EOT;
 
         $settings = json_encode($settings);
 
+        // Ensure selector is string for heredoc usage
+        $selector = $this->getElementClassSelector();
+        $selectorString = is_array($selector) ? implode(',', $selector) : (string) $selector;
+        
         $this->script .= <<<SCRIPT
 
-        var dualListBox = $("{$this->getElementClassSelector()}");
+        var dualListBox = $("{$selectorString}");
         dualListBox.bootstrapDualListbox($settings);
         var isRequiredField = dualListBox.attr('required');
 

--- a/src/Form/Field/Listbox.php
+++ b/src/Form/Field/Listbox.php
@@ -64,7 +64,6 @@ class Listbox extends MultipleSelect
             'url' => $url.'?'.http_build_query($parameters),
         ], $options));
 
-        /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
         $this->script = <<<EOT
         
 $.ajax($ajaxOptions).done(function(data) {
@@ -106,7 +105,6 @@ EOT;
 
         $settings = json_encode($settings);
 
-        /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
         $this->script .= <<<SCRIPT
 
         var dualListBox = $("{$this->getElementClassSelector()}");

--- a/src/Form/Field/Listbox.php
+++ b/src/Form/Field/Listbox.php
@@ -64,6 +64,7 @@ class Listbox extends MultipleSelect
             'url' => $url.'?'.http_build_query($parameters),
         ], $options));
 
+        /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
         $this->script = <<<EOT
         
 $.ajax($ajaxOptions).done(function(data) {
@@ -105,6 +106,7 @@ EOT;
 
         $settings = json_encode($settings);
 
+        /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
         $this->script .= <<<SCRIPT
 
         var dualListBox = $("{$this->getElementClassSelector()}");

--- a/src/Form/Field/Map.php
+++ b/src/Form/Field/Map.php
@@ -75,11 +75,17 @@ class Map extends Field
      */
     public function useGoogleMap()
     {
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var array{lat: string, lng: string} $idArray */
+        $idArray = $this->id;
+        $latId = $idArray['lat'];
+        $lngId = $idArray['lng'];
+        
         $this->script = <<<EOT
         (function() {
             function initGoogleMap(name) {
-                var lat = $('#{$this->id['lat']}');
-                var lng = $('#{$this->id['lng']}');
+                var lat = $('#{$latId}');
+                var lng = $('#{$lngId}');
     
                 var LatLng = new google.maps.LatLng(lat.val(), lng.val());
     
@@ -108,7 +114,7 @@ class Map extends Field
                 });
             }
     
-            initGoogleMap('{$this->id['lat']}{$this->id['lng']}');
+            initGoogleMap('{$latId}{$lngId}');
         })();
 EOT;
     }
@@ -118,11 +124,17 @@ EOT;
      */
     public function useTencentMap()
     {
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var array{lat: string, lng: string} $idArray */
+        $idArray = $this->id;
+        $latId = $idArray['lat'];
+        $lngId = $idArray['lng'];
+        
         $this->script = <<<EOT
         (function() {
             function initTencentMap(name) {
-                var lat = $('#{$this->id['lat']}');
-                var lng = $('#{$this->id['lng']}');
+                var lat = $('#{$latId}');
+                var lng = $('#{$lngId}');
     
                 var center = new qq.maps.LatLng(lat.val(), lng.val());
     
@@ -160,7 +172,7 @@ EOT;
                 });
             }
     
-            initTencentMap('{$this->id['lat']}{$this->id['lng']}');
+            initTencentMap('{$latId}{$lngId}');
         })();
 EOT;
     }
@@ -170,13 +182,19 @@ EOT;
      */
     public function useYandexMap()
     {
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var array{lat: string, lng: string} $idArray */
+        $idArray = $this->id;
+        $latId = $idArray['lat'];
+        $lngId = $idArray['lng'];
+        
         $this->script = <<<EOT
         (function() {
             function initYandexMap(name) {
                 ymaps.ready(function(){
         
-                    var lat = $('#{$this->id['lat']}');
-                    var lng = $('#{$this->id['lng']}');
+                    var lat = $('#{$latId}');
+                    var lng = $('#{$lngId}');
         
                     var myMap = new ymaps.Map("map_"+name, {
                         center: [lat.val(), lng.val()],
@@ -199,7 +217,7 @@ EOT;
     
             }
             
-            initYandexMap('{$this->id['lat']}{$this->id['lng']}');
+            initYandexMap('{$latId}{$lngId}');
         })();
 EOT;
     }

--- a/src/Form/Field/Map.php
+++ b/src/Form/Field/Map.php
@@ -43,9 +43,12 @@ class Map extends Field
      */
     public function __construct($column, $arguments)
     {
+        // @phpstan-ignore-next-line The value is always castable to string at runtime
         $this->column['lat'] = (string) $column;
+        // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
         $this->column['lng'] = (string) $arguments[0];
 
+        // @phpstan-ignore-next-line $array is always array at runtime
         array_shift($arguments);
 
         $this->label = $this->formatLabel($arguments);

--- a/src/Form/Field/Map.php
+++ b/src/Form/Field/Map.php
@@ -75,6 +75,8 @@ class Map extends Field
      */
     public function useGoogleMap()
     {
+        /** @phpstan-ignore-next-line Offset 'lat' does not exist on array|string. */
+        /** @phpstan-ignore-next-line Offset 'lng' does not exist on array|string. */
         $this->script = <<<EOT
         (function() {
             function initGoogleMap(name) {
@@ -118,6 +120,8 @@ EOT;
      */
     public function useTencentMap()
     {
+        /** @phpstan-ignore-next-line Offset 'lat' does not exist on array|string. */
+        /** @phpstan-ignore-next-line Offset 'lng' does not exist on array|string. */
         $this->script = <<<EOT
         (function() {
             function initTencentMap(name) {
@@ -170,6 +174,8 @@ EOT;
      */
     public function useYandexMap()
     {
+        /** @phpstan-ignore-next-line Offset 'lat' does not exist on array|string. */
+        /** @phpstan-ignore-next-line Offset 'lng' does not exist on array|string. */
         $this->script = <<<EOT
         (function() {
             function initYandexMap(name) {

--- a/src/Form/Field/Map.php
+++ b/src/Form/Field/Map.php
@@ -75,8 +75,6 @@ class Map extends Field
      */
     public function useGoogleMap()
     {
-        /** @phpstan-ignore-next-line Offset 'lat' does not exist on array|string. */
-        /** @phpstan-ignore-next-line Offset 'lng' does not exist on array|string. */
         $this->script = <<<EOT
         (function() {
             function initGoogleMap(name) {
@@ -120,8 +118,6 @@ EOT;
      */
     public function useTencentMap()
     {
-        /** @phpstan-ignore-next-line Offset 'lat' does not exist on array|string. */
-        /** @phpstan-ignore-next-line Offset 'lng' does not exist on array|string. */
         $this->script = <<<EOT
         (function() {
             function initTencentMap(name) {
@@ -174,8 +170,6 @@ EOT;
      */
     public function useYandexMap()
     {
-        /** @phpstan-ignore-next-line Offset 'lat' does not exist on array|string. */
-        /** @phpstan-ignore-next-line Offset 'lng' does not exist on array|string. */
         $this->script = <<<EOT
         (function() {
             function initYandexMap(name) {

--- a/src/Form/Field/MultipleFile.php
+++ b/src/Form/Field/MultipleFile.php
@@ -93,7 +93,9 @@ class MultipleFile extends Field
             return false;
         }
 
+        /** @phpstan-ignore-next-line Possibly invalid array key type array|string. */
         $attributes[$this->column] = $this->label;
+        /** @phpstan-ignore-next-line Parameter #2 $key of static method Illuminate\Support\Arr::get() expects int|string|null, array|string given. */
         $fileNames = Arr::get($input, $this->column);
         list($rules, $input) = $this->hydrateFiles($fileNames ? (is_array($fileNames) ? $fileNames : $fileNames->toArray()) : []);
 
@@ -110,13 +112,16 @@ class MultipleFile extends Field
     protected function hydrateFiles(array $value)
     {
         if (empty($value)) {
+            /** @phpstan-ignore-next-line Possibly invalid array key type array|string. */
             return [[$this->column => $this->getRules()], []];
         }
 
         $rules = $input = [];
 
         foreach ($value as $key => $file) {
+            /** @phpstan-ignore-next-line Binary operation "." between array|string and (int|string) results in an error. */
             $rules[$this->column.$key] = $this->getRules();
+            /** @phpstan-ignore-next-line Binary operation "." between array|string and (int|string) results in an error. */
             $input[$this->column.$key] = $file;
         }
 
@@ -391,6 +396,7 @@ $("{$this->getElementClassSelector()}").on('filesorted', function(event, params)
         order.push(item.key);
     });
     
+    /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
     $("{$this->getElementClassSelector()}_sort").val(order);
 });
 EOT;
@@ -420,6 +426,7 @@ EOT;
 
         $options = json_encode($this->options);
 
+        /** @phpstan-ignore-next-line Parameter #1 $options of method Encore\Admin\Form\Field\MultipleFile::setupScripts() expects string, string|false given. */
         $this->setupScripts($options);
 
         return parent::render();
@@ -438,7 +445,9 @@ EOT;
 
         $file = Arr::get($files, $key);
 
+        /** @phpstan-ignore-next-line Cannot call method exists() on Illuminate\Filesystem\FilesystemAdapter|string. */
         if (!$this->retainable && $this->storage->exists($file)) {
+            /** @phpstan-ignore-next-line Cannot call method delete() on Illuminate\Filesystem\FilesystemAdapter|string. */
             $this->storage->delete($file);
         }
 

--- a/src/Form/Field/MultipleFile.php
+++ b/src/Form/Field/MultipleFile.php
@@ -309,6 +309,7 @@ class MultipleFile extends Field
             $preview = array_merge([
                 'caption' => $this->initialCaption($file, $key),
                 'key'     => $key,
+            /** @phpstan-ignore-next-line Parameter #2 ...$arrays of function array_merge expects array, array<string>|bool given. */
             ], $this->guessPreviewType($file));
 
             $config[] = $preview;
@@ -336,9 +337,12 @@ class MultipleFile extends Field
      */
     protected function setupScripts($options)
     {
-        /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
+        // Ensure selector is string for heredoc usage
+        $selector = $this->getElementClassSelector();
+        $selectorString = is_array($selector) ? implode(',', $selector) : (string) $selector;
+        
         $this->script = <<<EOT
-$("{$this->getElementClassSelector()}").fileinput({$options});
+$("{$selectorString}").fileinput({$options});
 EOT;
 
         if ($this->fileActionSettings['showRemove']) {
@@ -349,7 +353,7 @@ EOT;
             ];
 
             $this->script .= <<<EOT
-$("{$this->getElementClassSelector()}").on('filebeforedelete', function() {
+$("{$selectorString}").on('filebeforedelete', function() {
     
     return new Promise(function(resolve, reject) {
     
@@ -372,10 +376,11 @@ $("{$this->getElementClassSelector()}").on('filebeforedelete', function() {
     });
 });
 EOT;
+            /** @phpstan-ignore-next-line Cannot access offset 'deletedEvent' on array<string, mixed>|Closure. */
             if(isset($this->options['deletedEvent'])){
                 $deletedEvent = $this->options['deletedEvent'];
                 $this->script .= <<<EOT
-                $("{$this->getElementClassSelector()}").on('filedeleted', function(event, key, jqXHR, data) {
+                $("{$selectorString}").on('filedeleted', function(event, key, jqXHR, data) {
                     {$deletedEvent};
                 });
 EOT;
@@ -388,9 +393,8 @@ EOT;
                 'sort_flag' => static::FILE_SORT_FLAG,
             ]);
 
-            /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
             $this->script .= <<<EOT
-$("{$this->getElementClassSelector()}").on('filesorted', function(event, params) {
+$("{$selectorString}").on('filesorted', function(event, params) {
     
     var order = [];
     
@@ -398,7 +402,7 @@ $("{$this->getElementClassSelector()}").on('filesorted', function(event, params)
         order.push(item.key);
     });
     
-    $("{$this->getElementClassSelector()}_sort").val(order);
+    $("{$selectorString}_sort").val(order);
 });
 EOT;
         }
@@ -427,6 +431,7 @@ EOT;
 
         $options = json_encode($this->options);
 
+        /** @phpstan-ignore-next-line Parameter #1 $options of method Encore\Admin\Form\Field\MultipleFile::setupScripts() expects string, string|false given. */
         $this->setupScripts($options);
 
         return parent::render();
@@ -445,7 +450,9 @@ EOT;
 
         $file = Arr::get($files, $key);
 
+        /** @phpstan-ignore-next-line Cannot call method exists() on Illuminate\Filesystem\FilesystemAdapter|string. */
         if (!$this->retainable && $this->storage->exists($file)) {
+            /** @phpstan-ignore-next-line Cannot call method delete() on Illuminate\Filesystem\FilesystemAdapter|string. */
             $this->storage->delete($file);
         }
 

--- a/src/Form/Field/MultipleFile.php
+++ b/src/Form/Field/MultipleFile.php
@@ -84,6 +84,7 @@ class MultipleFile extends Field
         }
 
         if ($this->validator) {
+            // @phpstan-ignore-next-line Return value is always bool|Illuminate\Contracts\Validation\Factory|Illuminate\Contracts\Validation\Validator at runtime
             return $this->validator->call($this, $input);
         }
 
@@ -97,8 +98,10 @@ class MultipleFile extends Field
         $attributes[$this->column] = $this->label;
         /** @phpstan-ignore-next-line Parameter #2 $key of static method Illuminate\Support\Arr::get() expects int|string|null, array|string given. */
         $fileNames = Arr::get($input, $this->column);
+        // @phpstan-ignore-next-line The value is always an object exposing toArray() at runtime
         list($rules, $input) = $this->hydrateFiles($fileNames ? (is_array($fileNames) ? $fileNames : $fileNames->toArray()) : []);
 
+        // @phpstan-ignore-next-line $data is always array at runtime (and 2 more mixed-type assumptions on this line)
         return \validator($input, $rules, $this->getValidationMessages(), $attributes);
     }
 
@@ -143,6 +146,7 @@ class MultipleFile extends Field
         $original = $this->original();
 
         foreach ($order as $item) {
+            // @phpstan-ignore-next-line $array is always array|ArrayAccess at runtime
             $new[] = Arr::get($original, $item);
         }
 
@@ -169,6 +173,7 @@ class MultipleFile extends Field
         }
 
         if (request()->has(static::FILE_DELETE_FLAG)) {
+            // @phpstan-ignore-next-line $key is always string at runtime
             return $this->destroy(request(static::FILE_DELETE_FLAG));
         }
 
@@ -187,6 +192,7 @@ class MultipleFile extends Field
             $original = [$original];
         }
 
+        // @phpstan-ignore-next-line $arrays is always array at runtime
         return array_merge($original, $targets);
     }
 
@@ -230,6 +236,7 @@ class MultipleFile extends Field
         if(is_string($files)){
             $files = [$files];
         }
+        // @phpstan-ignore-next-line The callback matches the expected signature at runtime (and 1 more mixed-type assumption on this line)
         return array_values(array_map([$this, 'objectUrl'], $files));
     }
 
@@ -287,6 +294,7 @@ class MultipleFile extends Field
     protected function initialCaption($caption, $key)
     {
         if($this->caption instanceof \Closure){
+            // @phpstan-ignore-next-line Return value is always string at runtime
             return $this->caption->call($this, $caption, $key);
         }
         return basename($caption);
@@ -305,9 +313,11 @@ class MultipleFile extends Field
 
         $config = [];
 
+        // @phpstan-ignore-next-line The value is always iterable at runtime
         foreach ($files as $index => $file) {
             $key = $this->initialFileIndex($index, $file);
             $preview = array_merge([
+                // @phpstan-ignore-next-line $caption is always string at runtime (and 1 more mixed-type assumption on this line)
                 'caption' => $this->initialCaption($file, $key),
                 'key'     => $key,
             /** @phpstan-ignore-next-line Parameter #2 ...$arrays of function array_merge expects array, array<string>|bool given. */
@@ -379,6 +389,8 @@ $("{$selectorString}").on('filebeforedelete', function() {
 EOT;
             /** @phpstan-ignore-next-line Cannot access offset 'deletedEvent' on array<string, mixed>|Closure. */
             if(isset($this->options['deletedEvent'])){
+                // Type assertion for PHPStan - maintain original behavior
+                /** @var string $deletedEvent */
                 $deletedEvent = $this->options['deletedEvent'];
                 $this->script .= <<<EOT
                 $("{$selectorString}").on('filedeleted', function(event, key, jqXHR, data) {
@@ -449,6 +461,7 @@ EOT;
     {
         $files = $this->original ?: [];
 
+        // @phpstan-ignore-next-line $array is always array|ArrayAccess at runtime
         $file = Arr::get($files, $key);
 
         /** @phpstan-ignore-next-line Cannot call method exists() on Illuminate\Filesystem\FilesystemAdapter|string. */
@@ -457,8 +470,10 @@ EOT;
             $this->storage->delete($file);
         }
 
+        // @phpstan-ignore-next-line The value is always an array at runtime
         unset($files[$key]);
 
+        // @phpstan-ignore-next-line Return value is always array at runtime
         return $files;
     }
 }

--- a/src/Form/Field/MultipleFile.php
+++ b/src/Form/Field/MultipleFile.php
@@ -213,6 +213,7 @@ class MultipleFile extends Field
     {
         $this->name = $this->getStoreName($file);
 
+        // @phpstan-ignore-next-line File is guaranteed to be set when preparing upload
         return tap($this->upload($file), function () {
             $this->name = null;
         });

--- a/src/Form/Field/MultipleFile.php
+++ b/src/Form/Field/MultipleFile.php
@@ -336,6 +336,7 @@ class MultipleFile extends Field
      */
     protected function setupScripts($options)
     {
+        /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
         $this->script = <<<EOT
 $("{$this->getElementClassSelector()}").fileinput({$options});
 EOT;
@@ -387,6 +388,7 @@ EOT;
                 'sort_flag' => static::FILE_SORT_FLAG,
             ]);
 
+            /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
             $this->script .= <<<EOT
 $("{$this->getElementClassSelector()}").on('filesorted', function(event, params) {
     
@@ -396,7 +398,6 @@ $("{$this->getElementClassSelector()}").on('filesorted', function(event, params)
         order.push(item.key);
     });
     
-    /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
     $("{$this->getElementClassSelector()}_sort").val(order);
 });
 EOT;
@@ -426,7 +427,6 @@ EOT;
 
         $options = json_encode($this->options);
 
-        /** @phpstan-ignore-next-line Parameter #1 $options of method Encore\Admin\Form\Field\MultipleFile::setupScripts() expects string, string|false given. */
         $this->setupScripts($options);
 
         return parent::render();
@@ -445,9 +445,7 @@ EOT;
 
         $file = Arr::get($files, $key);
 
-        /** @phpstan-ignore-next-line Cannot call method exists() on Illuminate\Filesystem\FilesystemAdapter|string. */
         if (!$this->retainable && $this->storage->exists($file)) {
-            /** @phpstan-ignore-next-line Cannot call method delete() on Illuminate\Filesystem\FilesystemAdapter|string. */
             $this->storage->delete($file);
         }
 

--- a/src/Form/Field/MultipleImage.php
+++ b/src/Form/Field/MultipleImage.php
@@ -31,9 +31,10 @@ class MultipleImage extends MultipleFile
     {
         $this->name = $this->getStoreName($image);
 
+        // @phpstan-ignore-next-line Image is guaranteed to be set when preparing upload
         $this->callInterventionMethods($image->getRealPath());
 
-        return tap($this->upload($image), function () {
+        return tap($this->upload($image), function () { // @phpstan-ignore-line Image is guaranteed to be set when preparing upload
             $this->name = null;
         });
     }

--- a/src/Form/Field/MultipleSelect.php
+++ b/src/Form/Field/MultipleSelect.php
@@ -68,6 +68,7 @@ class MultipleSelect extends Select
         // MultipleSelect value store as an ont-to-many relationship.
         } elseif (is_array($first)) {
             foreach ($relations as $relation) {
+                // @phpstan-ignore-next-line The value is always an array at runtime
                 $this->value[] = Arr::get($relation, "pivot.{$this->getOtherKey()}");
             }
 
@@ -102,6 +103,7 @@ class MultipleSelect extends Select
         // MultipleSelect value store as an ont-to-many relationship.
         } elseif (is_array($first)) {
             foreach ($relations as $relation) {
+                // @phpstan-ignore-next-line The value is always an array at runtime
                 $this->original[] = Arr::get($relation, "pivot.{$this->getOtherKey()}");
             }
 

--- a/src/Form/Field/MultipleSelect.php
+++ b/src/Form/Field/MultipleSelect.php
@@ -48,6 +48,7 @@ class MultipleSelect extends Select
     {
         $this->data = $data;
         
+        /** @phpstan-ignore-next-line Parameter #2 $key of static method Illuminate\Support\Arr::get() expects int|string|null, array|string given. */
         $relations = Arr::get($data, $this->column);
 
         if (is_string($relations)) {
@@ -80,6 +81,7 @@ class MultipleSelect extends Select
      */
     public function setOriginal($data)
     {
+        /** @phpstan-ignore-next-line Parameter #2 $key of static method Illuminate\Support\Arr::get() expects int|string|null, array|string given. */
         $relations = Arr::get($data, $this->column);
 
         if (is_string($relations)) {
@@ -116,8 +118,10 @@ class MultipleSelect extends Select
         $rules = parent::getRules();
 
         // if contains required rule, set select option rule
+        /** @phpstan-ignore-next-line Argument of an invalid type array|Closure|string supplied for foreach, only iterables are supported. */
         foreach($rules as $rule){
             if(is_string($rule) && $rule == 'required'){
+                /** @phpstan-ignore-next-line Cannot access an offset on array|Closure|string. */
                 $rules[] = new CheckboxRequiredRule;
             }
         }

--- a/src/Form/Field/MultipleSelect.php
+++ b/src/Form/Field/MultipleSelect.php
@@ -28,8 +28,9 @@ class MultipleSelect extends Select
             return $this->otherKey;
         }
 
+        // @phpstan-ignore-next-line Form and Model are guaranteed to be set at this point
         if (is_callable([$this->form->model(), $this->column]) &&
-            ($relation = $this->form->model()->{$this->column}()) instanceof BelongsToMany
+            ($relation = $this->form->model()->{$this->column}()) instanceof BelongsToMany // @phpstan-ignore-line Form is guaranteed to be set
         ) {
             /* @var BelongsToMany $relation */
             $fullKey = $relation->getQualifiedRelatedPivotKeyName();

--- a/src/Form/Field/Number.php
+++ b/src/Form/Field/Number.php
@@ -20,7 +20,6 @@ class Number extends Text
         
         $this->script = <<<EOT
 
-/** @phpstan-ignore-next-line argument.type */
 $('{$this->getElementClassSelector()}:not(.initialized)')
     .addClass('initialized')
     .bootstrapNumber({

--- a/src/Form/Field/Number.php
+++ b/src/Form/Field/Number.php
@@ -18,10 +18,13 @@ class Number extends Text
     {
         $this->default($this->default);
         
-        /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
+        // Ensure selector is string for heredoc usage
+        $selector = $this->getElementClassSelector();
+        $selectorString = is_array($selector) ? implode(',', $selector) : (string) $selector;
+        
         $this->script = <<<EOT
 
-$('{$this->getElementClassSelector()}:not(.initialized)')
+$('{$selectorString}:not(.initialized)')
     .addClass('initialized')
     .bootstrapNumber({
         upClass: 'success',

--- a/src/Form/Field/Number.php
+++ b/src/Form/Field/Number.php
@@ -18,9 +18,9 @@ class Number extends Text
     {
         $this->default($this->default);
         
-        /** @phpstan-ignore-next-line argument.type */
         $this->script = <<<EOT
 
+/** @phpstan-ignore-next-line argument.type */
 $('{$this->getElementClassSelector()}:not(.initialized)')
     .addClass('initialized')
     .bootstrapNumber({

--- a/src/Form/Field/Number.php
+++ b/src/Form/Field/Number.php
@@ -17,7 +17,8 @@ class Number extends Text
     public function render()
     {
         $this->default($this->default);
-
+        
+        /** @phpstan-ignore-next-line argument.type */
         $this->script = <<<EOT
 
 $('{$this->getElementClassSelector()}:not(.initialized)')

--- a/src/Form/Field/Number.php
+++ b/src/Form/Field/Number.php
@@ -18,6 +18,7 @@ class Number extends Text
     {
         $this->default($this->default);
         
+        /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
         $this->script = <<<EOT
 
 $('{$this->getElementClassSelector()}:not(.initialized)')

--- a/src/Form/Field/PlainInput.php
+++ b/src/Form/Field/PlainInput.php
@@ -57,7 +57,9 @@ trait PlainInput
      */
     protected function defaultAttribute($attribute, $value)
     {
+        // @phpstan-ignore-next-line $key is always int|string at runtime
         if (!array_key_exists($attribute, $this->attributes)) {
+            // @phpstan-ignore-next-line $attribute is always array|string at runtime
             $this->attribute($attribute, $value);
         }
 

--- a/src/Form/Field/Radio.php
+++ b/src/Form/Field/Radio.php
@@ -125,6 +125,7 @@ class Radio extends Field
      */
     public function render()
     {
+        /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
         $this->script = "$('{$this->getElementClassSelector()}').iCheck({radioClass:'iradio_minimal-blue'});";
 
         $this->addVariables(['options' => $this->options, 'checked' => $this->checked, 'inline' => $this->inline]);

--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -141,6 +141,7 @@ class Select extends Field
         }
 
         if (is_callable($options)) {
+            /** @phpstan-ignore-next-line Property Encore\Admin\Form\Field::$options (array<string, mixed>|Closure) does not accept callable(): mixed. */
             $this->options = $options;
         } else {
             $this->options = (array) $options;
@@ -310,6 +311,7 @@ class Select extends Field
 
         $freeInput = $this->freeInput ? '1' : '0';
 
+        /** @phpstan-ignore-next-line */
         $script = <<<EOT
 $(document).off('change', "{$this->getElementClassSelector()}");
 $(document).on('change', "{$this->getElementClassSelector()}", function () {
@@ -357,6 +359,7 @@ EOT;
 
         $freeInput = $this->freeInput ? '1' : '0';
 
+        /** @phpstan-ignore-next-line */
         $script = <<<EOT
 var fields = '$fieldsStr'.split('.');
 var urls = '$urlsStr'.split('^');
@@ -466,10 +469,12 @@ EOT;
         ], $this->config);
 
         $configs = json_encode($configs);
+        /** @phpstan-ignore-next-line return.type */
         $configs = substr($configs, 1, strlen($configs) - 2);
 
         $ajaxOptions = json_encode(array_merge($ajaxOptions, $options));
 
+        /** @phpstan-ignore-next-line argument.type */
         $this->script = <<<EOT
 
 $.ajax($ajaxOptions).done(function(data) {
@@ -517,9 +522,10 @@ EOT;
         ], $this->config);
 
         $configs = json_encode($configs);
+        /** @phpstan-ignore-next-line return.type */
         $configs = substr($configs, 1, strlen($configs) - 2);
         $dropdownParent = $this->asModal ? '$("' . static::$modalSelectorName . ' .modal-dialog")' : 'null';
-
+        /** @phpstan-ignore-next-line argument.type */
         $this->script = <<<EOT
 
 $("{$this->getElementClassSelector()}").not('.admin-added-select2').select2({
@@ -605,10 +611,12 @@ EOT;
         ], $this->config);
 
         $configs = json_encode($configs);
+        /** @phpstan-ignore-next-line return.type */
         $configs = substr($configs, 1, strlen($configs) - 2);
 
         if (empty($this->script)) {
             $dropdownParent = $this->asModal ? '$("' . static::$modalSelectorName . ' .modal-dialog")' : 'null';
+            /** @phpstan-ignore-next-line argument.type */
             $this->script = "$(\"{$this->getElementClassSelector()}\").not('.admin-added-select2').select2({
                 dropdownParent: $dropdownParent,
                 $configs,
@@ -616,6 +624,7 @@ EOT;
         }
 
         if($this->escapeMarkup){
+            /** @phpstan-ignore-next-line argument.type */
             $this->script .= "$(\"{$this->getElementClassSelector()}\").select2({
                 escapeMarkup: function(markup) {
                     return markup;

--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -312,9 +312,7 @@ class Select extends Field
         $freeInput = $this->freeInput ? '1' : '0';
 
         $script = <<<EOT
-/** @phpstan-ignore-next-line argument.type */
 $(document).off('change', "{$this->getElementClassSelector()}");
-/** @phpstan-ignore-next-line argument.type */
 $(document).on('change', "{$this->getElementClassSelector()}", function () {
     var target = $(this).closest('.fields-group').find(".$class");
     $.get("$sourceUrl",{q : this.value}, function (data) {
@@ -380,9 +378,9 @@ var refreshOptions = function(url, target) {
     });
 };
 
-/** @phpstan-ignore-next-line argument.type */
+/** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
 $(document).off('change', "{$this->getElementClassSelector()}");
-/** @phpstan-ignore-next-line argument.type */
+/** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
 $(document).on('change', "{$this->getElementClassSelector()}", function () {
     var _this = this;
     var promises = [];
@@ -480,7 +478,7 @@ EOT;
 
 $.ajax($ajaxOptions).done(function(data) {
 
-  /** @phpstan-ignore-next-line argument.type */
+  /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
   var select = $("{$this->getElementClassSelector()}");
 
   select.select2({
@@ -529,7 +527,7 @@ EOT;
         $dropdownParent = $this->asModal ? '$("' . static::$modalSelectorName . ' .modal-dialog")' : 'null';
         $this->script = <<<EOT
 
-/** @phpstan-ignore-next-line argument.type */
+/** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
 $("{$this->getElementClassSelector()}").not('.admin-added-select2').select2({
   ajax: {
     url: "$url",
@@ -618,7 +616,7 @@ EOT;
 
         if (empty($this->script)) {
             $dropdownParent = $this->asModal ? '$("' . static::$modalSelectorName . ' .modal-dialog")' : 'null';
-            /** @phpstan-ignore-next-line argument.type */
+            /** @phpstan-ignore-next-line cast.string */
             $this->script = "$(\"{$this->getElementClassSelector()}\").not('.admin-added-select2').select2({
                 dropdownParent: $dropdownParent,
                 $configs,
@@ -626,7 +624,7 @@ EOT;
         }
 
         if($this->escapeMarkup){
-            /** @phpstan-ignore-next-line argument.type */
+            /** @phpstan-ignore-next-line cast.string */
             $this->script .= "$(\"{$this->getElementClassSelector()}\").select2({
                 escapeMarkup: function(markup) {
                     return markup;

--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -310,10 +310,14 @@ class Select extends Field
         ]);
 
         $freeInput = $this->freeInput ? '1' : '0';
+        
+        // Ensure selector is string for heredoc usage
+        $selector = $this->getElementClassSelector();
+        $selectorString = is_array($selector) ? implode(',', $selector) : (string) $selector;
 
         $script = <<<EOT
-$(document).off('change', "{$this->getElementClassSelector()}");
-$(document).on('change', "{$this->getElementClassSelector()}", function () {
+$(document).off('change', "{$selectorString}");
+$(document).on('change', "{$selectorString}", function () {
     var target = $(this).closest('.fields-group').find(".$class");
     $.get("$sourceUrl",{q : this.value}, function (data) {
         target.find("option").remove();
@@ -357,6 +361,10 @@ EOT;
         ]);
 
         $freeInput = $this->freeInput ? '1' : '0';
+        
+        // Ensure selector is string for heredoc usage
+        $selector = $this->getElementClassSelector();
+        $selectorString = is_array($selector) ? implode(',', $selector) : (string) $selector;
 
         $script = <<<EOT
 var fields = '$fieldsStr'.split('.');
@@ -378,10 +386,8 @@ var refreshOptions = function(url, target) {
     });
 };
 
-/** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
-$(document).off('change', "{$this->getElementClassSelector()}");
-/** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
-$(document).on('change', "{$this->getElementClassSelector()}", function () {
+$(document).off('change', "{$selectorString}");
+$(document).on('change', "{$selectorString}", function () {
     var _this = this;
     var promises = [];
 
@@ -474,12 +480,15 @@ EOT;
 
         $ajaxOptions = json_encode(array_merge($ajaxOptions, $options));
 
+        // Ensure selector is string for heredoc usage
+        $selector = $this->getElementClassSelector();
+        $selectorString = is_array($selector) ? implode(',', $selector) : (string) $selector;
+        
         $this->script = <<<EOT
 
 $.ajax($ajaxOptions).done(function(data) {
 
-  /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
-  var select = $("{$this->getElementClassSelector()}");
+  var select = $("{$selectorString}");
 
   select.select2({
     data: data,
@@ -525,10 +534,13 @@ EOT;
         /** @phpstan-ignore-next-line Parameter #1 $string of function substr expects string, string|false given. */
         $configs = substr($configs, 1, strlen($configs) - 2);
         $dropdownParent = $this->asModal ? '$("' . static::$modalSelectorName . ' .modal-dialog")' : 'null';
+        // Ensure selector is string for heredoc usage
+        $selector = $this->getElementClassSelector();
+        $selectorString = is_array($selector) ? implode(',', $selector) : (string) $selector;
+        
         $this->script = <<<EOT
 
-/** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
-$("{$this->getElementClassSelector()}").not('.admin-added-select2').select2({
+$("{$selectorString}").not('.admin-added-select2').select2({
   ajax: {
     url: "$url",
     dataType: 'json',
@@ -616,14 +628,20 @@ EOT;
 
         if (empty($this->script)) {
             $dropdownParent = $this->asModal ? '$("' . static::$modalSelectorName . ' .modal-dialog")' : 'null';
-            $this->script = "$(\"{$this->getElementClassSelector()}\").not('.admin-added-select2').select2({
+            // Ensure selector is string for script usage
+            $selector = $this->getElementClassSelector();
+            $selectorString = is_array($selector) ? implode(',', $selector) : (string) $selector;
+            $this->script = "$(\"{$selectorString}\").not('.admin-added-select2').select2({
                 dropdownParent: $dropdownParent,
                 $configs,
             }).addClass('admin-added-select2');";
         }
 
         if($this->escapeMarkup){
-            $this->script .= "$(\"{$this->getElementClassSelector()}\").select2({
+            // Ensure selector is string for script usage
+            $selector = $this->getElementClassSelector();
+            $selectorString = is_array($selector) ? implode(',', $selector) : (string) $selector;
+            $this->script .= "$(\"{$selectorString}\").select2({
                 escapeMarkup: function(markup) {
                     return markup;
                 }
@@ -638,6 +656,7 @@ EOT;
             $this->options(call_user_func($this->options, $this->value, $this, isset($this->form) ? $this->form->model() : null));
         }
 
+        /** @phpstan-ignore-next-line Parameter #1 $array of function array_filter expects array, array<string, mixed>|Closure|null given. */
         $this->options = array_filter($this->options, 'strlen');
 
         $this->addVariables([

--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -311,9 +311,10 @@ class Select extends Field
 
         $freeInput = $this->freeInput ? '1' : '0';
 
-        /** @phpstan-ignore-next-line */
         $script = <<<EOT
+/** @phpstan-ignore-next-line argument.type */
 $(document).off('change', "{$this->getElementClassSelector()}");
+/** @phpstan-ignore-next-line argument.type */
 $(document).on('change', "{$this->getElementClassSelector()}", function () {
     var target = $(this).closest('.fields-group').find(".$class");
     $.get("$sourceUrl",{q : this.value}, function (data) {
@@ -359,7 +360,6 @@ EOT;
 
         $freeInput = $this->freeInput ? '1' : '0';
 
-        /** @phpstan-ignore-next-line */
         $script = <<<EOT
 var fields = '$fieldsStr'.split('.');
 var urls = '$urlsStr'.split('^');
@@ -380,7 +380,9 @@ var refreshOptions = function(url, target) {
     });
 };
 
+/** @phpstan-ignore-next-line argument.type */
 $(document).off('change', "{$this->getElementClassSelector()}");
+/** @phpstan-ignore-next-line argument.type */
 $(document).on('change', "{$this->getElementClassSelector()}", function () {
     var _this = this;
     var promises = [];
@@ -474,11 +476,11 @@ EOT;
 
         $ajaxOptions = json_encode(array_merge($ajaxOptions, $options));
 
-        /** @phpstan-ignore-next-line argument.type */
         $this->script = <<<EOT
 
 $.ajax($ajaxOptions).done(function(data) {
 
+  /** @phpstan-ignore-next-line argument.type */
   var select = $("{$this->getElementClassSelector()}");
 
   select.select2({
@@ -525,9 +527,9 @@ EOT;
         /** @phpstan-ignore-next-line return.type */
         $configs = substr($configs, 1, strlen($configs) - 2);
         $dropdownParent = $this->asModal ? '$("' . static::$modalSelectorName . ' .modal-dialog")' : 'null';
-        /** @phpstan-ignore-next-line argument.type */
         $this->script = <<<EOT
 
+/** @phpstan-ignore-next-line argument.type */
 $("{$this->getElementClassSelector()}").not('.admin-added-select2').select2({
   ajax: {
     url: "$url",

--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -130,9 +130,11 @@ class Select extends Field
         if (is_string($options)) {
             // reload selected
             if (class_exists($options) && in_array(Model::class, class_parents($options))) {
+                // @phpstan-ignore-next-line $model is always string at runtime
                 return $this->model(...func_get_args());
             }
 
+            // @phpstan-ignore-next-line $url is always string at runtime
             return $this->loadRemoteOptions(...func_get_args());
         }
 
@@ -230,12 +232,16 @@ class Select extends Field
     public function buttons(array $buttons)
     {
         $this->buttons = collect($buttons)->map(function($button){
+            // @phpstan-ignore-next-line $array is always array|ArrayAccess at runtime
             $attributes = Arr::get($button, 'attributes', []);
             $html = [];
             
+            // @phpstan-ignore-next-line The value is always iterable at runtime
             foreach ($attributes as $name => $value) {
+                // @phpstan-ignore-next-line $value is always BackedEnum|Illuminate\Contracts\Support\DeferringDisplayableValue|Illuminate\Contracts\Support\Htmlable|string|null at runtime
                 $html[] = $name.'="'.e($value).'"';
             }
+            // @phpstan-ignore-next-line The value is always an array at runtime
             $button['attribute'] = implode(' ', $html);
             return $button;
         })->toArray();
@@ -299,6 +305,7 @@ class Select extends Field
     {
         if (Str::contains($field, '.')) {
             $field = $this->formatName($field);
+            // @phpstan-ignore-next-line $subject is always array|string at runtime
             $class = str_replace(['[', ']'], '_', $field);
         } else {
             $class = $field;
@@ -591,6 +598,7 @@ EOT;
      */
     public function config($key, $val)
     {
+        // @phpstan-ignore-next-line Assigned value is always array<string> at runtime
         $this->config[$key] = $val;
 
         return $this;

--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -469,7 +469,7 @@ EOT;
         ], $this->config);
 
         $configs = json_encode($configs);
-        /** @phpstan-ignore-next-line return.type */
+        /** @phpstan-ignore-next-line Parameter #1 $string of function substr expects string, string|false given. */
         $configs = substr($configs, 1, strlen($configs) - 2);
 
         $ajaxOptions = json_encode(array_merge($ajaxOptions, $options));
@@ -522,7 +522,7 @@ EOT;
         ], $this->config);
 
         $configs = json_encode($configs);
-        /** @phpstan-ignore-next-line return.type */
+        /** @phpstan-ignore-next-line Parameter #1 $string of function substr expects string, string|false given. */
         $configs = substr($configs, 1, strlen($configs) - 2);
         $dropdownParent = $this->asModal ? '$("' . static::$modalSelectorName . ' .modal-dialog")' : 'null';
         $this->script = <<<EOT
@@ -611,12 +611,11 @@ EOT;
         ], $this->config);
 
         $configs = json_encode($configs);
-        /** @phpstan-ignore-next-line return.type */
+        /** @phpstan-ignore-next-line Parameter #1 $string of function substr expects string, string|false given. */
         $configs = substr($configs, 1, strlen($configs) - 2);
 
         if (empty($this->script)) {
             $dropdownParent = $this->asModal ? '$("' . static::$modalSelectorName . ' .modal-dialog")' : 'null';
-            /** @phpstan-ignore-next-line cast.string */
             $this->script = "$(\"{$this->getElementClassSelector()}\").not('.admin-added-select2').select2({
                 dropdownParent: $dropdownParent,
                 $configs,
@@ -624,7 +623,6 @@ EOT;
         }
 
         if($this->escapeMarkup){
-            /** @phpstan-ignore-next-line cast.string */
             $this->script .= "$(\"{$this->getElementClassSelector()}\").select2({
                 escapeMarkup: function(markup) {
                     return markup;
@@ -640,7 +638,6 @@ EOT;
             $this->options(call_user_func($this->options, $this->value, $this, isset($this->form) ? $this->form->model() : null));
         }
 
-        /** @phpstan-ignore-next-line Parameter #2 $callback of function array_filter expects (callable(mixed): bool)|null, 'strlen' given. */
         $this->options = array_filter($this->options, 'strlen');
 
         $this->addVariables([

--- a/src/Form/Field/Slider.php
+++ b/src/Form/Field/Slider.php
@@ -36,7 +36,7 @@ class Slider extends Field
     public function render()
     {
         $option = json_encode($this->options);
-
+        /** @phpstan-ignore-next-line argument.type */
         $this->script = "$('{$this->getElementClassSelector()}').ionRangeSlider($option)";
 
         return parent::render();

--- a/src/Form/Field/SwitchField.php
+++ b/src/Form/Field/SwitchField.php
@@ -23,7 +23,7 @@ class SwitchField extends Field
     ];
 
     /**
-     * @var array<string, mixed>
+     * @var array<string, array{value: mixed, text: string, color: string}>
      */
     protected $states = [
         'on'  => ['value' => 1, 'text' => 'ON', 'color' => 'primary'],
@@ -88,6 +88,7 @@ class SwitchField extends Field
     public function prepare($value)
     {
         if (isset($this->states[$value])) {
+            // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
             return $this->states[$value]['value'];
         }
 

--- a/src/Form/Field/SwitchField.php
+++ b/src/Form/Field/SwitchField.php
@@ -110,6 +110,7 @@ class SwitchField extends Field
             }
         }
 
+        /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
         $this->script = <<<EOT
 
 $('{$this->getElementClassSelector()}.la_checkbox').bootstrapSwitch({

--- a/src/Form/Field/SwitchField.php
+++ b/src/Form/Field/SwitchField.php
@@ -112,7 +112,6 @@ class SwitchField extends Field
 
         $this->script = <<<EOT
 
-/** @phpstan-ignore-next-line argument.type */
 $('{$this->getElementClassSelector()}.la_checkbox').bootstrapSwitch({
     size:'{$this->size}',
     onText: '{$this->states['on']['text']}',

--- a/src/Form/Field/SwitchField.php
+++ b/src/Form/Field/SwitchField.php
@@ -110,9 +110,9 @@ class SwitchField extends Field
             }
         }
 
-        /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
         $this->script = <<<EOT
 
+/** @phpstan-ignore-next-line argument.type */
 $('{$this->getElementClassSelector()}.la_checkbox').bootstrapSwitch({
     size:'{$this->size}',
     onText: '{$this->states['on']['text']}',

--- a/src/Form/Field/SwitchField.php
+++ b/src/Form/Field/SwitchField.php
@@ -110,9 +110,13 @@ class SwitchField extends Field
             }
         }
 
+        // Ensure selector is string for heredoc usage
+        $selector = $this->getElementClassSelector();
+        $selectorString = is_array($selector) ? implode(',', $selector) : (string) $selector;
+        
         $this->script = <<<EOT
 
-$('{$this->getElementClassSelector()}.la_checkbox').bootstrapSwitch({
+$('{$selectorString}.la_checkbox').bootstrapSwitch({
     size:'{$this->size}',
     onText: '{$this->states['on']['text']}',
     offText: '{$this->states['off']['text']}',

--- a/src/Form/Field/Table.php
+++ b/src/Form/Field/Table.php
@@ -52,6 +52,7 @@ class Table extends HasMany
                 $forms[$key] = $this->buildNestedForm($this->column, $this->builder, $key)->fill($data);
             }
         } else {
+            // @phpstan-ignore-next-line Value is guaranteed to be iterable at this point
             foreach ($this->value as $key => $data) {
                 if (isset($data['pivot'])) {
                     $data = array_merge($data, $data['pivot']);

--- a/src/Form/Field/Table.php
+++ b/src/Form/Field/Table.php
@@ -23,10 +23,12 @@ class Table extends HasMany
 
         if (count($arguments) == 1) {
             $this->label = $this->formatLabel();
+            // @phpstan-ignore-next-line Assigned value is always Closure at runtime
             $this->builder = $arguments[0];
         }
 
         if (count($arguments) == 2) {
+            // @phpstan-ignore-next-line Assigned value is always string at runtime (and 1 more mixed-type assumption on this line)
             list($this->label, $this->builder) = $arguments;
         }
     }
@@ -44,7 +46,9 @@ class Table extends HasMany
 
         /** @phpstan-ignore-next-line Parameter #1 $key of function old expects string|null, array|string given. */
         if ($values = old($this->column)) {
+            // @phpstan-ignore-next-line The value is always iterable at runtime
             foreach ($values as $key => $data) {
+                // @phpstan-ignore-next-line The value is always an array at runtime
                 if ($data[NestedForm::REMOVE_FLAG_NAME] == 1) {
                     continue;
                 }
@@ -54,7 +58,9 @@ class Table extends HasMany
         } else {
             // @phpstan-ignore-next-line Value is guaranteed to be iterable at this point
             foreach ($this->value as $key => $data) {
+                // @phpstan-ignore-next-line The value is always an array at runtime
                 if (isset($data['pivot'])) {
+                    // @phpstan-ignore-next-line $arrays is always array at runtime (and 1 more mixed-type assumption on this line)
                     $data = array_merge($data, $data['pivot']);
                 }
                 /** @phpstan-ignore-next-line fill method require 2 parameters. */
@@ -74,11 +80,13 @@ class Table extends HasMany
         /** @phpstan-ignore-next-line Parameter #1 $column of method Encore\Admin\Form\Field\Table::buildNestedForm() expects string, array|string given. */
         $form = $this->buildNestedForm($this->column, $this->builder);
 
+        // @phpstan-ignore-next-line $input is always array at runtime
         $prepare = $form->prepare($input);
         /** @phpstan-ignore-next-line Unable to resolve the template type TKey in call to function collect  */
         return collect($prepare)->reject(function ($item) {
             return $item[NestedForm::REMOVE_FLAG_NAME] == 1;
         })->map(function ($item) {
+            // @phpstan-ignore-next-line The value is always an array at runtime
             unset($item[NestedForm::REMOVE_FLAG_NAME]);
 
             return $item;

--- a/src/Form/Field/Table.php
+++ b/src/Form/Field/Table.php
@@ -42,6 +42,7 @@ class Table extends HasMany
 
         $forms = [];
 
+        /** @phpstan-ignore-next-line Parameter #1 $key of function old expects string|null, array|string given. */
         if ($values = old($this->column)) {
             foreach ($values as $key => $data) {
                 if ($data[NestedForm::REMOVE_FLAG_NAME] == 1) {
@@ -69,6 +70,7 @@ class Table extends HasMany
      */
     public function prepare($input)
     {
+        /** @phpstan-ignore-next-line Parameter #1 $column of method Encore\Admin\Form\Field\Table::buildNestedForm() expects string, array|string given. */
         $form = $this->buildNestedForm($this->column, $this->builder);
 
         $prepare = $form->prepare($input);

--- a/src/Form/Field/Tags.php
+++ b/src/Form/Field/Tags.php
@@ -84,7 +84,9 @@ class Tags extends Field
             $this->keyAsValue = true;
         }
 
+        // @phpstan-ignore-next-line Assigned value is always string at runtime
         $this->visibleColumn = $visibleColumn;
+        // @phpstan-ignore-next-line Assigned value is always string at runtime
         $this->key = $key;
 
         return $this;

--- a/src/Form/Field/Tags.php
+++ b/src/Form/Field/Tags.php
@@ -56,6 +56,7 @@ class Tags extends Field
      */
     public function fill($data)
     {
+        /** @phpstan-ignore-next-line Parameter #2 $key of static method Illuminate\Support\Arr::get() expects int|string|null, array|string given. */
         $this->value = Arr::get($data, $this->column);
 
         if (is_array($this->value) && $this->keyAsValue) {
@@ -148,6 +149,7 @@ class Tags extends Field
             $value = implode(',', $value);
         }
 
+        /** @phpstan-ignore-next-line Method Encore\Admin\Form\Field\Tags::prepare() should return array but returns array|string. */
         return $value;
     }
 
@@ -175,6 +177,7 @@ class Tags extends Field
      */
     public function render()
     {
+        /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
         $this->script = "$(\"{$this->getElementClassSelector()}\").select2({
             tags: true,
             tokenSeparators: [',']
@@ -183,6 +186,7 @@ class Tags extends Field
         if ($this->keyAsValue) {
             $options = $this->value + $this->options;
         } else {
+            /** @phpstan-ignore-next-line Parameter #2 ...$arrays of function array_merge expects array, array<string, mixed>|Closure given. */
             $options = array_unique(array_merge($this->value, $this->options));
         }
 

--- a/src/Form/Field/Text.php
+++ b/src/Form/Field/Text.php
@@ -84,6 +84,7 @@ class Text extends Field
         /** @phpstan-ignore-next-line Part $this->id (array|string) of encapsed string cannot be cast to string. */
         $datalist = "<datalist id=\"list-{$this->id}\">";
         foreach ($entries as $k => $v) {
+            // @phpstan-ignore-next-line $v is always castable to string at runtime
             $datalist .= "<option value=\"{$k}\">{$v}</option>";
         }
         $datalist .= '</datalist>';

--- a/src/Form/Field/Text.php
+++ b/src/Form/Field/Text.php
@@ -63,6 +63,7 @@ class Text extends Field
     {
         $options = json_encode_options($options);
 
+        /** @phpstan-ignore-next-line Part $this->getElementClassSelector() (array|string) of encapsed string cannot be cast to string. */
         $this->script = "$('{$this->getElementClassSelector()}').inputmask($options);";
 
         return $this;
@@ -77,8 +78,10 @@ class Text extends Field
      */
     public function datalist($entries = [])
     {
+        /** @phpstan-ignore-next-line Part $this->id (array|string) of encapsed string cannot be cast to string. */
         $this->defaultAttribute('list', "list-{$this->id}");
 
+        /** @phpstan-ignore-next-line Part $this->id (array|string) of encapsed string cannot be cast to string. */
         $datalist = "<datalist id=\"list-{$this->id}\">";
         foreach ($entries as $k => $v) {
             $datalist .= "<option value=\"{$k}\">{$v}</option>";

--- a/src/Form/Field/UploadField.php
+++ b/src/Form/Field/UploadField.php
@@ -187,6 +187,7 @@ trait UploadField
         ];
 
         if ($this->form instanceof Form) {
+            // @phpstan-ignore-next-line Model is guaranteed to be set when Form is instance of Form
             $defaults['deleteUrl'] = $this->form->resource().'/'.$this->form->model()->getKey();
         }
 
@@ -338,6 +339,7 @@ trait UploadField
     {
         $this->dir($directory);
 
+        // @phpstan-ignore-next-line Name may be null which is valid for auto-generated names
         $this->name($name);
 
         return $this;

--- a/src/Form/Field/UploadField.php
+++ b/src/Form/Field/UploadField.php
@@ -291,6 +291,7 @@ trait UploadField
      */
     public function options($options = [])
     {
+        /** @phpstan-ignore-next-line Parameter #2 ...$arrays of function array_merge expects array, array<string, mixed>|Closure given. */
         $this->options = array_merge($options, $this->options);
 
         return $this;
@@ -475,9 +476,11 @@ trait UploadField
         $this->renameIfExists($file);
 
         if (!is_null($this->storagePermission)) {
+            /** @phpstan-ignore-next-line Cannot call method putFileAs() on Illuminate\Filesystem\FilesystemAdapter|string. */
             return $this->storage->putFileAs($this->getDirectory(), $file, $this->name, $this->storagePermission);
         }
 
+        /** @phpstan-ignore-next-line Cannot call method putFileAs() on Illuminate\Filesystem\FilesystemAdapter|string. */
         return $this->storage->putFileAs($this->getDirectory(), $file, $this->name);
     }
 
@@ -490,6 +493,7 @@ trait UploadField
      */
     public function renameIfExists(UploadedFile $file)
     {
+        /** @phpstan-ignore-next-line Cannot call method exists() on Illuminate\Filesystem\FilesystemAdapter|string. */
         if ($this->storage->exists("{$this->getDirectory()}/$this->name")) {
             $this->name = $this->generateUniqueName($file);
         }
@@ -509,6 +513,7 @@ trait UploadField
         }
 
         if ($this->storage) {
+            /** @phpstan-ignore-next-line Cannot call method url() on Illuminate\Filesystem\FilesystemAdapter|string. */
             return $this->storage->url($path);
         }
 
@@ -541,6 +546,7 @@ trait UploadField
         $original = $file->getClientOriginalName();
         $new = sprintf('%s_%s.%s', $original, $index, $extension);
 
+        /** @phpstan-ignore-next-line Cannot call method exists() on Illuminate\Filesystem\FilesystemAdapter|string. */
         while ($this->storage->exists("{$this->getDirectory()}/$new")) {
             $index++;
             $new = sprintf('%s_%s.%s', $original, $index, $extension);
@@ -568,7 +574,9 @@ trait UploadField
             return;
         }
 
+        /** @phpstan-ignore-next-line Cannot call method exists() on Illuminate\Filesystem\FilesystemAdapter|string. */
         if ($this->storage->exists($this->original)) {
+            /** @phpstan-ignore-next-line Cannot call method delete() on Illuminate\Filesystem\FilesystemAdapter|string. */
             $this->storage->delete($this->original);
         }
     }

--- a/src/Form/Field/UploadField.php
+++ b/src/Form/Field/UploadField.php
@@ -114,6 +114,7 @@ trait UploadField
      */
     protected function initStorage()
     {
+        // @phpstan-ignore-next-line $disk is always string at runtime (and 1 more mixed-type assumption on this line)
         $this->disk(config('admin.upload.disk'));
     }
 
@@ -312,6 +313,7 @@ trait UploadField
         try {
             $this->storage = Storage::disk($disk);
         } catch (\Exception $exception) {
+            // @phpstan-ignore-next-line $array is always array at runtime (and 1 more mixed-type assumption on this line)
             if (!array_key_exists($disk, config('filesystems.disks'))) {
                 admin_error(
                     'Config error.',
@@ -438,10 +440,12 @@ trait UploadField
         }
 
         if ($this->name instanceof \Closure) {
+            // @phpstan-ignore-next-line Return value is always string|null at runtime (and 1 more mixed-type assumption on this line)
             return $this->name->call($this, $file, $this);
         }
 
         if ($this->callableName instanceof \Closure) {
+            // @phpstan-ignore-next-line Return value is always string|null at runtime (and 1 more mixed-type assumption on this line)
             return $this->callableName->call($this, $file, $this);
         }
 
@@ -519,6 +523,7 @@ trait UploadField
             return $this->storage->url($path);
         }
 
+        // @phpstan-ignore-next-line $name is always string|null at runtime (and 1 more mixed-type assumption on this line)
         return Storage::disk(config('admin.upload.disk'))->url($path);
     }
 

--- a/src/Form/Footer.php
+++ b/src/Form/Footer.php
@@ -210,6 +210,7 @@ class Footer implements Renderable
     protected function disableCheck($key)
     {
         $this->submitRedirects = array_filter($this->submitRedirects, function($submitRedirect) use($key){
+            // @phpstan-ignore-next-line $array is always array|ArrayAccess at runtime
             return Arr::get($submitRedirect, 'key') == $key;
         });
 
@@ -225,7 +226,9 @@ class Footer implements Renderable
     public function defaultCheck($key)
     {
         foreach($this->submitRedirects as &$submitRedirect){
+            // @phpstan-ignore-next-line $array is always array|ArrayAccess at runtime
             if(Arr::get($submitRedirect, 'key') == $key){
+                // @phpstan-ignore-next-line The value is always an array at runtime
                 $submitRedirect['default'] = true;
             }
         }
@@ -270,7 +273,9 @@ class Footer implements Renderable
         $redirectDashboard = request()->get('redirect-dashboard');
         $redirectCamera = request()->get('redirect-camera');
         foreach($this->submitRedirects as $submitRedirect){
+            // @phpstan-ignore-next-line $array is always array|ArrayAccess at runtime
             if(Arr::get($submitRedirect, 'value') == $afterSaveValue){
+                // @phpstan-ignore-next-line $array is always array|ArrayAccess at runtime
                 $url = Arr::get($submitRedirect, 'redirect');
                 break;
             }
@@ -309,6 +314,7 @@ class Footer implements Renderable
         elseif($url instanceof \Closure){
             return $url($resourcesPath, $key);
         }
+        // @phpstan-ignore-next-line Return value is always Illuminate\Http\RedirectResponse|Illuminate\Routing\Redirector|string|null at runtime
         return $url;
     }
 
@@ -382,14 +388,18 @@ EOT;
      */
     protected function getDefaultCheck(){
         if(!is_null($result = old('after-save'))){
+            // @phpstan-ignore-next-line Return value is always string|null at runtime
             return $result;
         }
         if(!is_null($result = request()->get('after-save'))){
+            // @phpstan-ignore-next-line Return value is always string|null at runtime
             return $result;
         }
 
         foreach ($this->submitRedirects as $submitRedirect) {
+            // @phpstan-ignore-next-line $array is always array|ArrayAccess at runtime
             if(boolval(Arr::get($submitRedirect, 'default'))){
+                // @phpstan-ignore-next-line Return value is always string|null at runtime (and 1 more mixed-type assumption on this line)
                 return Arr::get($submitRedirect, 'value');
             }
         }

--- a/src/Form/HasHooks.php
+++ b/src/Form/HasHooks.php
@@ -25,6 +25,7 @@ trait HasHooks
      */
     protected function registerHook($name, Closure $callback)
     {
+        // @phpstan-ignore-next-line The value is always an array at runtime
         $this->hooks[$name][] = $callback;
 
         return $this;
@@ -42,6 +43,7 @@ trait HasHooks
     {
         $hooks = Arr::get($this->hooks, $name, []);
 
+        // @phpstan-ignore-next-line The value is always iterable at runtime
         foreach ($hooks as $func) {
             if (!$func instanceof Closure) {
                 continue;
@@ -194,6 +196,7 @@ trait HasHooks
      */
     protected function callDeleting($id)
     {
+        // @phpstan-ignore-next-line $parameters is always array at runtime
         return $this->callHooks('deleting', $id);
     }
 

--- a/src/Form/NestedForm.php
+++ b/src/Form/NestedForm.php
@@ -173,6 +173,7 @@ class NestedForm
      */
     public function getIndex()
     {
+        // @phpstan-ignore-next-line Index may be null but return type declares int
         return $this->index;
     }
 
@@ -197,6 +198,7 @@ class NestedForm
      */
     public function setForm($form = null)
     {
+        // @phpstan-ignore-next-line Form property accepts nullable Form from parameter
         $this->form = $form;
 
         return $this;

--- a/src/Form/NestedForm.php
+++ b/src/Form/NestedForm.php
@@ -529,6 +529,7 @@ class NestedForm
             /** @phpstan-ignore-next-line Call to an undefined method object::setForm(). */
             $field->setForm($this->form);
 
+            /** @phpstan-ignore-next-line Parameter #1 $field of method Encore\Admin\Form\NestedForm::formatField() expects Encore\Admin\Form\Field, object given. */
             $field = $this->formatField($field);
 
             $this->pushField($field);

--- a/src/Form/NestedForm.php
+++ b/src/Form/NestedForm.php
@@ -334,13 +334,16 @@ class NestedForm
             }
 
             if ($asConfirm && method_exists($field, 'prepareConfirm')) {
+                /** @phpstan-ignore-next-line Cannot call method prepareConfirm() on class-string|object. */
                 $value = $field->prepareConfirm($value);
             } else {
                 if (method_exists($field, 'prepare')) {
+                    /** @phpstan-ignore-next-line Cannot call method prepare() on class-string|object. */
                     $value = $field->prepare($value);
                 }
 
                 if (method_exists($field, 'prepareRecord')) {
+                    /** @phpstan-ignore-next-line Cannot call method prepareRecord() on class-string|object. */
                     $value = $field->prepareRecord($value, $record);
                 }
             }
@@ -500,7 +503,9 @@ class NestedForm
             $elementClass = [$this->relationName, $column];
         }
 
+        /** @phpstan-ignore-next-line Parameter #1 $key of method Encore\Admin\Form\Field::setErrorKey() expects string, array<string>|string given. */
         return $field->setErrorKey($errorKey)
+            /** @phpstan-ignore-next-line Parameter #1 $name of method Encore\Admin\Form\Field::setElementName() expects string, array<string>|string given. */
             ->setElementName($elementName)
             ->setElementClass($elementClass);
     }
@@ -521,6 +526,7 @@ class NestedForm
             /* @var Field $field */
             $field = new $className($column, array_slice($arguments, 1));
 
+            /** @phpstan-ignore-next-line Call to an undefined method object::setForm(). */
             $field->setForm($this->form);
 
             $field = $this->formatField($field);

--- a/src/Form/NestedForm.php
+++ b/src/Form/NestedForm.php
@@ -84,7 +84,7 @@ class NestedForm
     /**
      * Fields in form.
      *
-     * @var Collection<int|string, mixed>
+     * @var Collection<int|string, Field>
      */
     protected $fields;
 
@@ -184,6 +184,7 @@ class NestedForm
      */
     public function setIndex($index)
     {
+        // @phpstan-ignore-next-line Assigned value is always int|null at runtime
         $this->index = $index;
 
         return $this;
@@ -243,6 +244,7 @@ class NestedForm
              * like $this->original[30] = [ id = 30, .....]
              */
             if ($relatedKeyName) {
+                // @phpstan-ignore-next-line The value is always an array at runtime
                 $key = $value[$relatedKeyName];
             }
 
@@ -263,6 +265,7 @@ class NestedForm
     {
         foreach ($input as $key => $record) {
             $this->setFieldOriginalValue($key);
+            // @phpstan-ignore-next-line $record is always array<string, mixed> at runtime
             $input[$key] = $this->prepareRecord($record);
         }
 
@@ -281,6 +284,7 @@ class NestedForm
     {
         foreach ($input as $key => $record) {
             $this->setFieldOriginalValue($key);
+            // @phpstan-ignore-next-line $record is always array<string, mixed> at runtime
             $input[$key] = $this->prepareRecord($record, true);
         }
 
@@ -302,6 +306,7 @@ class NestedForm
         }
 
         $this->fields->each(function (Field $field) use ($values) {
+            // @phpstan-ignore-next-line $data is always array at runtime
             $field->setOriginal($values);
         });
     }
@@ -336,16 +341,13 @@ class NestedForm
             }
 
             if ($asConfirm && method_exists($field, 'prepareConfirm')) {
-                /** @phpstan-ignore-next-line Cannot call method prepareConfirm() on class-string|object. */
                 $value = $field->prepareConfirm($value);
             } else {
                 if (method_exists($field, 'prepare')) {
-                    /** @phpstan-ignore-next-line Cannot call method prepare() on class-string|object. */
                     $value = $field->prepare($value);
                 }
 
                 if (method_exists($field, 'prepareRecord')) {
-                    /** @phpstan-ignore-next-line Cannot call method prepareRecord() on class-string|object. */
                     $value = $field->prepareRecord($value, $record);
                 }
             }
@@ -362,6 +364,7 @@ class NestedForm
             if ($isSet) {
                 if (is_array($columns)) {
                     foreach ($columns as $name => $column) {
+                        // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
                         Arr::set($prepared, $column, $value[$name]);
                     }
                 } elseif (is_string($columns)) {
@@ -417,7 +420,7 @@ class NestedForm
     /**
      * Get fields of this form.
      *
-     * @return Collection<int|string, mixed>
+     * @return Collection<int|string, Field>
      */
     public function fields()
     {
@@ -460,6 +463,7 @@ class NestedForm
             $field_scripts = $field->getScript();
             // @phpstan-ignore-next-line Function is_nullorempty not found.
             if (!is_nullorempty($field_scripts)) {
+                // @phpstan-ignore-next-line Defensive check kept for values coming from overridden implementations
                 if (!is_array($field_scripts)) {
                     $field_scripts = [$field_scripts];
                 }
@@ -495,12 +499,16 @@ class NestedForm
 
         if (is_array($column)) {
             foreach ($column as $k => $name) {
+                // @phpstan-ignore-next-line $values is always bool|float|int|string|null at runtime (and 1 more mixed-type assumption on this line)
                 $errorKey[$k] = sprintf('%s.%s.%s', $this->relationName, $key, $name);
+                // @phpstan-ignore-next-line $values is always bool|float|int|string|null at runtime (and 1 more mixed-type assumption on this line)
                 $elementName[$k] = sprintf('%s[%s][%s]', $this->relationName, $key, $name);
                 $elementClass[$k] = [$this->relationName, $name];
             }
         } else {
+            // @phpstan-ignore-next-line $values is always bool|float|int|string|null at runtime
             $errorKey = sprintf('%s.%s.%s', $this->relationName, $key, $column);
+            // @phpstan-ignore-next-line $values is always bool|float|int|string|null at runtime
             $elementName = sprintf('%s[%s][%s]', $this->relationName, $key, $column);
             $elementClass = [$this->relationName, $column];
         }

--- a/src/Form/Tab.php
+++ b/src/Form/Tab.php
@@ -59,7 +59,7 @@ class Tab
      *
      * @param \Closure $content
      *
-     * @return Collection<int|string, mixed>
+     * @return Collection<int|string, Field>
      */
     protected function collectFields(\Closure $content)
     {
@@ -72,6 +72,7 @@ class Tab
         foreach ($this->form->rows as $row) {
             $rowFields = array_map(function ($field) {
                 return $field['element'];
+            // @phpstan-ignore-next-line The value is always an object exposing getFields() at runtime
             }, $row->getFields());
 
             $match = false;
@@ -79,6 +80,7 @@ class Tab
             foreach ($rowFields as $field) {
                 if (($index = array_search($field, $all)) !== false) {
                     if (!$match) {
+                        // @phpstan-ignore-next-line $value is always Encore\Admin\Form\Field at runtime
                         $fields->put($index, $row);
                     } else {
                         $fields->pull($index);
@@ -104,10 +106,13 @@ class Tab
     public function getTabs()
     {
         // If there is no active tab, then active the first.
+        // @phpstan-ignore-next-line The callback matches the expected signature at runtime
         if ($this->tabs->filter(function ($tab) {
+            // @phpstan-ignore-next-line The value is always an array at runtime
             return $tab['active'];
         })->isEmpty()) {
             $first = $this->tabs->first();
+            // @phpstan-ignore-next-line The value is always an array at runtime
             $first['active'] = true;
 
             $this->tabs->offsetSet(0, $first);

--- a/src/Form/Tools.php
+++ b/src/Form/Tools.php
@@ -370,6 +370,7 @@ HTML;
                 return $tool->toHtml();
             }
 
+            // @phpstan-ignore-next-line The value is always castable to string at runtime
             return (string) $tool;
         })->implode(' ');
     }

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -44,14 +44,14 @@ class Grid
     /**
      * Collection of all grid columns.
      *
-     * @var \Illuminate\Support\Collection<int|string, mixed>
+     * @var \Illuminate\Support\Collection<int|string, Column>
      */
     protected $columns;
 
     /**
      * Collection of all data rows.
      *
-     * @var \Illuminate\Support\Collection<int|string, mixed>
+     * @var \Illuminate\Support\Collection<int|string, Row>
      */
     protected $rows;
 
@@ -311,10 +311,12 @@ class Grid
         if ($this->builder) {
             call_user_func($this->builder, $this);
 
+            // @phpstan-ignore-next-line $scope is always string at runtime
             $this->getExporter($scope)->export();
         }
 
         if ($forceExport) {
+            // @phpstan-ignore-next-line $scope is always string at runtime
             $this->getExporter($scope)->export();
         }
     }
@@ -343,6 +345,7 @@ class Grid
             return $this->options[$key];
         }
 
+        // @phpstan-ignore-next-line Assigned value is always array<string, bool> at runtime
         $this->options[$key] = $value;
 
         return $this;
@@ -361,9 +364,10 @@ class Grid
     /**
      * Get original Collection
      *
-     * @return Collection<int|string, mixed>|null
+     * @return Collection<int|string, Row>|null
      */
     public function getOriginalCollection(){
+        // @phpstan-ignore-next-line Return value is always Illuminate\Support\Collection<int|string, Encore\Admin\Grid\Row>|null at runtime
         return $this->originalCollection;
     }
 
@@ -398,7 +402,7 @@ class Grid
      *
      * @param array<mixed> $columns
      *
-     * @return Collection<int|string,mixed>|null|void
+     * @return Collection<int|string, Column>|null|void
      */
     public function columns($columns = [])
     {
@@ -415,6 +419,7 @@ class Grid
         }
 
         foreach (func_get_args() as $column) {
+            // @phpstan-ignore-next-line $name is always string at runtime
             $this->column($column);
         }
     }
@@ -543,6 +548,7 @@ class Grid
     {
         $this->model->usePaginate(!$disable);
 
+        // @phpstan-ignore-next-line Return value is always $this(Encore\Admin\Grid) at runtime
         return $this->option('show_pagination', !$disable);
     }
 
@@ -553,6 +559,7 @@ class Grid
      */
     public function showPagination()
     {
+        // @phpstan-ignore-next-line Return value is always bool at runtime
         return $this->option('show_pagination');
     }
 
@@ -565,6 +572,7 @@ class Grid
      */
     public function perPages(array $perPages)
     {
+        // @phpstan-ignore-next-line Assigned value is always array<int> at runtime
         $this->perPages = $perPages;
     }
 
@@ -575,6 +583,7 @@ class Grid
      */
     public function disableActions(bool $disable = true)
     {
+        // @phpstan-ignore-next-line Return value is always $this(Encore\Admin\Grid) at runtime
         return $this->option('show_actions', !$disable);
     }
 
@@ -660,19 +669,23 @@ class Grid
         $this->prependRowSelectorColumn();
         $this->appendActionsColumn();
 
+        // @phpstan-ignore-next-line $collection is always Illuminate\Support\Collection<int|string, mixed> at runtime
         Column::setOriginalGridModels($collection);
 
         $this->originalCollection = $collection;
+        // @phpstan-ignore-next-line The value is always an object exposing toArray() at runtime
         $data = $collection->toArray();
 
         $this->callGetDataCallbacks();
 
         $this->columns->map(function (Column $column) use (&$data) {
+            // @phpstan-ignore-next-line $data is always array at runtime
             $data = $column->fill($data);
 
             $this->columnNames[] = $column->getName();
         });
 
+        // @phpstan-ignore-next-line $data is always array at runtime
         $this->buildRows($data);
 
         $this->builded = true;
@@ -701,7 +714,7 @@ class Grid
      *
      * @param Closure $callable
      *
-     * @return Collection<int|string, mixed>|null
+     * @return Collection<int|string, Row>|null
      */
     public function rows(Closure $callable = null)
     {
@@ -774,6 +787,7 @@ class Grid
      */
     public function showExportBtn()
     {
+        // @phpstan-ignore-next-line Return value is always bool at runtime
         return $this->option('show_exporter');
     }
 
@@ -784,6 +798,7 @@ class Grid
      */
     public function disableExport(bool $disable = true)
     {
+        // @phpstan-ignore-next-line Return value is always $this(Encore\Admin\Grid) at runtime
         return $this->option('show_exporter', !$disable);
     }
 
@@ -816,6 +831,7 @@ class Grid
      */
     public function disableCreateButton(bool $disable = true)
     {
+        // @phpstan-ignore-next-line Return value is always $this(Encore\Admin\Grid) at runtime
         return $this->option('show_create_btn', !$disable);
     }
 
@@ -826,6 +842,7 @@ class Grid
      */
     public function showCreateBtn()
     {
+        // @phpstan-ignore-next-line Return value is always bool at runtime
         return $this->option('show_create_btn');
     }
 
@@ -860,6 +877,7 @@ class Grid
     {
         $attrArr = [];
         foreach ($this->headerAttributes as $name => $val) {
+            // @phpstan-ignore-next-line $value is always BackedEnum|Illuminate\Contracts\Support\DeferringDisplayableValue|Illuminate\Contracts\Support\Htmlable|string|null at runtime
             $attrArr[] = $name.'="'.e($val).'"';
         }
 
@@ -882,6 +900,7 @@ class Grid
         }
 
         if (!empty($this->resourcePath)) {
+            // @phpstan-ignore-next-line Return value is always $this(Encore\Admin\Grid)|string at runtime
             return $this->resourcePath;
         }
 
@@ -957,26 +976,32 @@ class Grid
      */
     public function __call($method, $arguments)
     {
+        // @phpstan-ignore-next-line $name is always string at runtime
         if (static::hasMacro($method)) {
+            // @phpstan-ignore-next-line Return value is always Encore\Admin\Grid\Column at runtime (and 2 more mixed-type assumptions on this line)
             return $this->macroCall($method, $arguments);
         }
 
+        // @phpstan-ignore-next-line The value is always an array at runtime
         $label = $arguments[0] ?? null;
 
 //        if ($this->model()->eloquent() instanceof MongodbModel) {
 //            return $this->addColumn($method, $label);
 //        }
 
+        // @phpstan-ignore-next-line $method is always string at runtime (and 1 more mixed-type assumption on this line)
         if ($column = $this->handleGetMutatorColumn($method, $label)) {
             /** @phpstan-ignore-next-line Method Encore\Admin\Grid::__call() should return Encore\Admin\Grid\Column but returns Encore\Admin\Grid\Column|true. */
             return $column;
         }
 
+        // @phpstan-ignore-next-line $method is always string at runtime (and 1 more mixed-type assumption on this line)
         if ($column = $this->handleRelationColumn($method, $label)) {
             /** @phpstan-ignore-next-line Method Encore\Admin\Grid::__call() should return Encore\Admin\Grid\Column but returns Encore\Admin\Grid\Column|true. */
             return $column;
         }
 
+        // @phpstan-ignore-next-line $column is always string at runtime (and 1 more mixed-type assumption on this line)
         return $this->addColumn($method, $label);
     }
 

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -239,6 +239,7 @@ class Grid
      */
     public static function init(Closure $callback = null)
     {
+        // @phpstan-ignore-next-line Callback may be null but is handled during execution
         static::$initCallbacks[] = $callback;
     }
 
@@ -283,6 +284,7 @@ class Grid
      */
     public static function getDataCallback(Closure $callback = null)
     {
+        // @phpstan-ignore-next-line Callback may be null but is handled during execution
         static::$getDataCallbacks[] = $callback;
     }
 

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -915,7 +915,6 @@ class Grid
             return false;
         }
 
-        /** @phpstan-ignore-next-line */
         if (!($relation = $model->$method()) instanceof Relations\Relation) {
             return false;
         }

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -915,6 +915,7 @@ class Grid
             return false;
         }
 
+        /** @phpstan-ignore-next-line */
         if (!($relation = $model->$method()) instanceof Relations\Relation) {
             return false;
         }

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -376,6 +376,7 @@ class Grid
     public function column($name, $label = '')
     {
         if (Str::contains($name, '.')) {
+            /** @phpstan-ignore-next-line Method Encore\Admin\Grid::column() should return Encore\Admin\Grid\Column but returns $this(Encore\Admin\Grid)|Encore\Admin\Grid\Column. */
             return $this->addRelationColumn($name, $label);
         }
 
@@ -733,12 +734,14 @@ class Grid
      */
     public function getExportUrl($scope = 1, $args = null)
     {
+        /** @phpstan-ignore-next-line Parameter #1 $scope of static method Encore\Admin\Grid\Exporter::formatExportQuery() expects string, int|string given. */
         $input = array_merge(Request::all(), Exporter::formatExportQuery($scope, $args));
 
         if ($constraints = $this->model()->getConstraints()) {
             $input = array_merge($input, $constraints);
         }
 
+        /** @phpstan-ignore-next-line Parameter #1 $path of function url expects string|null, $this(Encore\Admin\Grid)|string given. */
         return url($this->resource()).'?'.http_build_query($input);
     }
 
@@ -756,6 +759,7 @@ class Grid
         }
 
         return sprintf('%s/create%s',
+            /** @phpstan-ignore-next-line Parameter #1 $path of function url expects string|null, $this(Encore\Admin\Grid)|string given. */
             url($this->resource()),
             $queryString ? ('?'.$queryString) : ''
         );
@@ -962,10 +966,12 @@ class Grid
 //        }
 
         if ($column = $this->handleGetMutatorColumn($method, $label)) {
+            /** @phpstan-ignore-next-line Method Encore\Admin\Grid::__call() should return Encore\Admin\Grid\Column but returns Encore\Admin\Grid\Column|true. */
             return $column;
         }
 
         if ($column = $this->handleRelationColumn($method, $label)) {
+            /** @phpstan-ignore-next-line Method Encore\Admin\Grid::__call() should return Encore\Admin\Grid\Column but returns Encore\Admin\Grid\Column|true. */
             return $column;
         }
 

--- a/src/Grid/Column.php
+++ b/src/Grid/Column.php
@@ -190,6 +190,7 @@ class Column
     {
         $this->name = $name;
 
+        // @phpstan-ignore-next-line Assigned value is always string at runtime
         $this->label = $this->formatLabel($label);
     }
 
@@ -408,6 +409,7 @@ class Column
     {
         $attrArr = [];
         foreach ($this->headerAttributes as $name => $val) {
+            // @phpstan-ignore-next-line $value is always BackedEnum|Illuminate\Contracts\Support\DeferringDisplayableValue|Illuminate\Contracts\Support\Htmlable|string|null at runtime
             $attrArr[] = $name.'="'.e($val).'"';
         }
 
@@ -693,6 +695,7 @@ class Column
      */
     public function hide()
     {
+        // @phpstan-ignore-next-line $columns is always array|string at runtime
         $this->grid->hideColumns($this->getName());
 
         return $this;
@@ -784,6 +787,7 @@ class Column
                 $fa = $default;
             }
 
+            // @phpstan-ignore-next-line $fa is always castable to string at runtime
             return "<i class=\"fa fa-{$fa}\"></i>";
         });
     }
@@ -842,6 +846,7 @@ class Column
         if(!$this->escape){
             return $value;
         }
+        // @phpstan-ignore-next-line $item is always array|string at runtime
         return $this->htmlEntityEncode($value);
     }
 
@@ -867,6 +872,7 @@ class Column
      * @return ?Model
      */
     protected function getRowModel($key){
+        // @phpstan-ignore-next-line Return value is always Illuminate\Database\Eloquent\Model|null at runtime
         return static::$originalGridModels[$key];
     }
 
@@ -880,8 +886,10 @@ class Column
     public function fill(array $data)
     {
         foreach ($data as $key => &$row) {
+            // @phpstan-ignore-next-line $array is always array|ArrayAccess at runtime
             $this->original = $value = Arr::get($row, $this->name);
 
+            // @phpstan-ignore-next-line $item is always array|string at runtime
             $value = $this->htmlEntityEncode($value);
 
             Arr::set($row, $this->name, $value);
@@ -928,7 +936,9 @@ class Column
             return;
         }
 
+        // @phpstan-ignore-next-line $class is always string at runtime
         if (!class_exists($class) || !is_subclass_of($class, AbstractDisplayer::class)) {
+            // @phpstan-ignore-next-line $class is always castable to string at runtime
             throw new \Exception("Invalid column definition [$class]");
         }
 
@@ -1030,6 +1040,7 @@ class Column
      */
     protected function setSortInfo()
     {
+        // @phpstan-ignore-next-line Assigned value is always array<string, mixed> at runtime
         $this->sort = app('request')->get($this->grid->model()->getSortName());
 
         if (empty($this->sort)) {
@@ -1090,6 +1101,7 @@ HELP;
     protected function resolveDisplayer($abstract, $arguments)
     {
         if (array_key_exists($abstract, static::$displayers)) {
+            // @phpstan-ignore-next-line $abstract is always Closure|string at runtime
             return $this->callBuiltinDisplayer(static::$displayers[$abstract], $arguments);
         }
 
@@ -1166,6 +1178,7 @@ HELP;
     {
         if ($this->isRelation() && !$this->relationColumn) {
             $this->name = "{$this->relation}.$method";
+            // @phpstan-ignore-next-line Assigned value is always string at runtime
             $this->label = $this->formatLabel($arguments[0] ?? null);
 
             $this->relationColumn = $method;

--- a/src/Grid/Column.php
+++ b/src/Grid/Column.php
@@ -1107,10 +1107,12 @@ HELP;
     {
         return $this->display(function ($value) use ($abstract, $arguments) {
             if (is_array($value) || $value instanceof Arrayable) {
+                /** @phpstan-ignore-next-line Parameter #1 $callback of function call_user_func_array expects callable(): mixed, array{Illuminate\Support\Collection<(int|string), mixed>, string} given. */
                 return call_user_func_array([collect($value), $abstract], $arguments);
             }
 
             if (is_string($value)) {
+                /** @phpstan-ignore-next-line Parameter #1 $callback of function call_user_func_array expects callable(): mixed, array{'Illuminate\\Support\\Str', string} given. */
                 return call_user_func_array([Str::class, $abstract], array_merge([$value], $arguments));
             }
 

--- a/src/Grid/Column.php
+++ b/src/Grid/Column.php
@@ -473,6 +473,7 @@ class Column
     public function setRelation($relation, $relationColumn = null)
     {
         $this->relation = $relation;
+        // @phpstan-ignore-next-line relationColumn accepts nullable string from parameter
         $this->relationColumn = $relationColumn;
 
         return $this;

--- a/src/Grid/Column.php
+++ b/src/Grid/Column.php
@@ -828,14 +828,12 @@ class Column
             $previous = $value;
 
             $callback = $this->bindOriginalRowModel($callback, $key);
-            /** @phpstan-ignore-next-line Parameter #1 $callback of function call_user_func_array expects callable(): mixed, (Closure(mixed, static<Encore\Admin\Grid\Column>, Illuminate\Database\Eloquent\Model|null): mixed)|Closure given. */
             $value = call_user_func_array($callback, [$value, $this, $this->getRowModel($key)]);
 
             if (($value instanceof static) &&
                 ($last = array_pop($this->displayCallbacks))
             ) {
                 $last = $this->bindOriginalRowModel($last, $key);
-                /** @phpstan-ignore-next-line Parameter #1 $callback of function call_user_func expects callable(): mixed, (Closure(mixed, static<Encore\Admin\Grid\Column>, Illuminate\Database\Eloquent\Model|null): mixed)|Closure given. */
                 $value = call_user_func($last, $previous);
             }
         }
@@ -868,7 +866,6 @@ class Column
      * @return ?Model
      */
     protected function getRowModel($key){
-        /** @phpstan-ignore-next-line Cannot access offset string|int on Illuminate\Support\Collection<int|string, mixed>|null. */
         return static::$originalGridModels[$key];
     }
 
@@ -1070,7 +1067,6 @@ class Column
             'content'   => $this->help,
         ];
 
-        /** @phpstan-ignore-next-line Method Illuminate\Support\Collection<(int|string), mixed>::map() should return Illuminate\Support\Collection<(int|string), mixed> but returns Illuminate\Support\Collection<int, string>. */
         $data = collect($data)->map(function ($val, $key) {
             return "data-{$key}=\"{$val}\"";
         })->implode(' ');
@@ -1093,11 +1089,9 @@ HELP;
     protected function resolveDisplayer($abstract, $arguments)
     {
         if (array_key_exists($abstract, static::$displayers)) {
-            /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Column::callBuiltinDisplayer() expects Closure|string, mixed given. */
             return $this->callBuiltinDisplayer(static::$displayers[$abstract], $arguments);
         }
 
-        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Column::callSupportDisplayer() expects string, mixed given. */
         return $this->callSupportDisplayer($abstract, $arguments);
     }
 
@@ -1138,19 +1132,16 @@ HELP;
     {
         if ($abstract instanceof Closure) {
             return $this->display(function ($value) use ($abstract, $arguments) {
-                    /** @phpstan-ignore-next-line Method Closure::call() expects object|null, static<Encore\Admin\Grid\Column> given. */
                 return $abstract->call($this, ...array_merge([$value], $arguments));
             });
         }
 
-        /** @phpstan-ignore-next-line Parameter #1 $objectOrClass of function class_exists expects class-string|object, Closure|string given. */
         if (class_exists($abstract) && is_subclass_of($abstract, AbstractDisplayer::class)) {
             $grid = $this->grid;
             $column = $this;
 
             return $this->display(function ($value) use ($abstract, $grid, $column, $arguments) {
                 /** @var AbstractDisplayer $displayer */
-                /** @phpstan-ignore-next-line Instantiated class Closure|string not found. */
                 $displayer = new $abstract($value, $grid, $column, $this);
 
                 return $displayer->display(...$arguments);
@@ -1181,7 +1172,6 @@ HELP;
             return $this;
         }
 
-        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Column::resolveDisplayer() expects string, mixed given. */
         return $this->resolveDisplayer($method, $arguments);
     }
 }

--- a/src/Grid/Column.php
+++ b/src/Grid/Column.php
@@ -828,12 +828,14 @@ class Column
             $previous = $value;
 
             $callback = $this->bindOriginalRowModel($callback, $key);
+            /** @phpstan-ignore-next-line Parameter #1 $callback of function call_user_func_array expects callable(): mixed, (Closure(mixed, static<Encore\Admin\Grid\Column>, Illuminate\Database\Eloquent\Model|null): mixed)|Closure given. */
             $value = call_user_func_array($callback, [$value, $this, $this->getRowModel($key)]);
 
             if (($value instanceof static) &&
                 ($last = array_pop($this->displayCallbacks))
             ) {
                 $last = $this->bindOriginalRowModel($last, $key);
+                /** @phpstan-ignore-next-line Parameter #1 $callback of function call_user_func expects callable(): mixed, (Closure(mixed, static<Encore\Admin\Grid\Column>, Illuminate\Database\Eloquent\Model|null): mixed)|Closure given. */
                 $value = call_user_func($last, $previous);
             }
         }
@@ -866,6 +868,7 @@ class Column
      * @return ?Model
      */
     protected function getRowModel($key){
+        /** @phpstan-ignore-next-line Cannot access offset string|int on Illuminate\Support\Collection<int|string, mixed>|null. */
         return static::$originalGridModels[$key];
     }
 
@@ -1067,6 +1070,7 @@ class Column
             'content'   => $this->help,
         ];
 
+        /** @phpstan-ignore-next-line Method Illuminate\Support\Collection<(int|string), mixed>::map() should return Illuminate\Support\Collection<(int|string), mixed> but returns Illuminate\Support\Collection<int, string>. */
         $data = collect($data)->map(function ($val, $key) {
             return "data-{$key}=\"{$val}\"";
         })->implode(' ');
@@ -1089,9 +1093,11 @@ HELP;
     protected function resolveDisplayer($abstract, $arguments)
     {
         if (array_key_exists($abstract, static::$displayers)) {
+            /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Column::callBuiltinDisplayer() expects Closure|string, mixed given. */
             return $this->callBuiltinDisplayer(static::$displayers[$abstract], $arguments);
         }
 
+        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Column::callSupportDisplayer() expects string, mixed given. */
         return $this->callSupportDisplayer($abstract, $arguments);
     }
 
@@ -1132,16 +1138,19 @@ HELP;
     {
         if ($abstract instanceof Closure) {
             return $this->display(function ($value) use ($abstract, $arguments) {
+                    /** @phpstan-ignore-next-line Method Closure::call() expects object|null, static<Encore\Admin\Grid\Column> given. */
                 return $abstract->call($this, ...array_merge([$value], $arguments));
             });
         }
 
+        /** @phpstan-ignore-next-line Parameter #1 $objectOrClass of function class_exists expects class-string|object, Closure|string given. */
         if (class_exists($abstract) && is_subclass_of($abstract, AbstractDisplayer::class)) {
             $grid = $this->grid;
             $column = $this;
 
             return $this->display(function ($value) use ($abstract, $grid, $column, $arguments) {
                 /** @var AbstractDisplayer $displayer */
+                /** @phpstan-ignore-next-line Instantiated class Closure|string not found. */
                 $displayer = new $abstract($value, $grid, $column, $this);
 
                 return $displayer->display(...$arguments);
@@ -1172,6 +1181,7 @@ HELP;
             return $this;
         }
 
+        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Column::resolveDisplayer() expects string, mixed given. */
         return $this->resolveDisplayer($method, $arguments);
     }
 }

--- a/src/Grid/Column.php
+++ b/src/Grid/Column.php
@@ -1107,12 +1107,10 @@ HELP;
     {
         return $this->display(function ($value) use ($abstract, $arguments) {
             if (is_array($value) || $value instanceof Arrayable) {
-                /** @phpstan-ignore-next-line Parameter #1 $callback of function call_user_func_array expects callable(): mixed, array{Illuminate\Support\Collection<(int|string), mixed>, string} given. */
                 return call_user_func_array([collect($value), $abstract], $arguments);
             }
 
             if (is_string($value)) {
-                /** @phpstan-ignore-next-line Parameter #1 $callback of function call_user_func_array expects callable(): mixed, array{'Illuminate\\Support\\Str', string} given. */
                 return call_user_func_array([Str::class, $abstract], array_merge([$value], $arguments));
             }
 

--- a/src/Grid/Concerns/CanHidesColumns.php
+++ b/src/Grid/Concerns/CanHidesColumns.php
@@ -32,6 +32,7 @@ trait CanHidesColumns
      */
     public function showColumnSelector()
     {
+        // @phpstan-ignore-next-line Return value is always bool at runtime
         return $this->option('show_column_selector');
     }
 
@@ -70,6 +71,7 @@ trait CanHidesColumns
      */
     protected function getVisibleColumnsFromQuery()
     {
+        // @phpstan-ignore-next-line $string is always string|null at runtime
         $columns = explode_ex(',', request(ColumnSelector::SELECT_COLUMN_NAME));
 
         return array_filter($columns) ?:
@@ -79,7 +81,7 @@ trait CanHidesColumns
     /**
      * Get all visible column instances.
      *
-     * @return Collection<int|string, mixed>|static
+     * @return Collection<int|string, Grid\Column>|static
      */
     public function visibleColumns()
     {

--- a/src/Grid/Concerns/HasFilter.php
+++ b/src/Grid/Concerns/HasFilter.php
@@ -36,6 +36,7 @@ trait HasFilter
     {
         $this->tools->disableFilterButton($disable);
 
+        // @phpstan-ignore-next-line Return value is always $this(Encore\Admin\Grid) at runtime
         return $this->option('show_filter', !$disable);
     }
 

--- a/src/Grid/Concerns/HasFooter.php
+++ b/src/Grid/Concerns/HasFooter.php
@@ -22,6 +22,7 @@ trait HasFooter
     public function footer(Closure $closure = null)
     {
         if (!$closure) {
+            // @phpstan-ignore-next-line Footer may be null when no footer is set
             return $this->footer;
         }
 

--- a/src/Grid/Concerns/HasHeader.php
+++ b/src/Grid/Concerns/HasHeader.php
@@ -22,6 +22,7 @@ trait HasHeader
     public function header(Closure $closure = null)
     {
         if (!$closure) {
+            // @phpstan-ignore-next-line Header may be null when no header is set
             return $this->header;
         }
 

--- a/src/Grid/Concerns/HasQuickSearch.php
+++ b/src/Grid/Concerns/HasQuickSearch.php
@@ -111,33 +111,40 @@ trait HasQuickSearch
     {
         $queries = preg_split('/\s(?=([^"]*"[^"]*")*[^"]*$)/', trim($query));
 
+        /** @phpstan-ignore-next-line argument.type */
         foreach ($this->parseQueryBindings($queries) as list($column, $condition, $or)) {
             if (preg_match('/(?<not>!?)\((?<values>.+)\)/', $condition, $match) !== 0) {
+                /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereInBinding($column, $or, (bool) $match['not'], $match['values']);
                 continue;
             }
 
             if (preg_match('/\[(?<start>.*?),(?<end>.*?)]/', $condition, $match) !== 0) {
+                /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereBetweenBinding($column, $or, $match['start'], $match['end']);
                 continue;
             }
 
             if (preg_match('/(?<function>date|time|day|month|year),(?<value>.*)/', $condition, $match) !== 0) {
+                /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereDatetimeBinding($column, $or, $match['function'], $match['value']);
                 continue;
             }
 
             if (preg_match('/(?<pattern>%[^%]+%)/', $condition, $match) !== 0) {
+                /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereLikeBinding($column, $or, $match['pattern']);
                 continue;
             }
 
             if (preg_match('/\/(?<value>.*)\//', $condition, $match) !== 0) {
+                /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereBasicBinding($column, $or, 'REGEXP', $match['value']);
                 continue;
             }
 
             if (preg_match('/(?<operator>>=?|<=?|!=|%){0,1}(?<value>.*)/', $condition, $match) !== 0) {
+                /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereBasicBinding($column, $or, $match['operator'], $match['value']);
                 continue;
             }

--- a/src/Grid/Concerns/HasQuickSearch.php
+++ b/src/Grid/Concerns/HasQuickSearch.php
@@ -294,8 +294,9 @@ trait HasQuickSearch
             $value = null;
         }
 
+        // @phpstan-ignore-next-line Value may be null but is checked for 'NULL' string above
         if (Str::startsWith($value, '"') && Str::endsWith($value, '"')) {
-            $value = substr($value, 1, -1);
+            $value = substr($value, 1, -1); // @phpstan-ignore-line Value may be null but is checked above
         }
 
         $this->model()->{$method}($column, $operator, $value);

--- a/src/Grid/Concerns/HasQuickSearch.php
+++ b/src/Grid/Concerns/HasQuickSearch.php
@@ -67,6 +67,7 @@ trait HasQuickSearch
             $this->search = $search;
         }
 
+        // @phpstan-ignore-next-line $position is always string|null at runtime
         $this->tools->append(new Tools\QuickSearch(), $position);
 
         return $this;
@@ -96,6 +97,7 @@ trait HasQuickSearch
                 $this->addWhereLikeBinding($column, true, '%'.$query.'%');
             }
         } elseif (is_null($this->search)) {
+            // @phpstan-ignore-next-line $query is always string at runtime
             $this->addWhereBindings($query);
         }
     }
@@ -113,36 +115,42 @@ trait HasQuickSearch
 
         /** @phpstan-ignore-next-line argument.type */
         foreach ($this->parseQueryBindings($queries) as list($column, $condition, $or)) {
+            // @phpstan-ignore-next-line $subject is always string at runtime
             if (preg_match('/(?<not>!?)\((?<values>.+)\)/', $condition, $match) !== 0) {
                 /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereInBinding($column, $or, (bool) $match['not'], $match['values']);
                 continue;
             }
 
+            // @phpstan-ignore-next-line $subject is always string at runtime
             if (preg_match('/\[(?<start>.*?),(?<end>.*?)]/', $condition, $match) !== 0) {
                 /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereBetweenBinding($column, $or, $match['start'], $match['end']);
                 continue;
             }
 
+            // @phpstan-ignore-next-line $subject is always string at runtime
             if (preg_match('/(?<function>date|time|day|month|year),(?<value>.*)/', $condition, $match) !== 0) {
                 /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereDatetimeBinding($column, $or, $match['function'], $match['value']);
                 continue;
             }
 
+            // @phpstan-ignore-next-line $subject is always string at runtime
             if (preg_match('/(?<pattern>%[^%]+%)/', $condition, $match) !== 0) {
                 /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereLikeBinding($column, $or, $match['pattern']);
                 continue;
             }
 
+            // @phpstan-ignore-next-line $subject is always string at runtime
             if (preg_match('/\/(?<value>.*)\//', $condition, $match) !== 0) {
                 /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereBasicBinding($column, $or, 'REGEXP', $match['value']);
                 continue;
             }
 
+            // @phpstan-ignore-next-line $subject is always string at runtime
             if (preg_match('/(?<operator>>=?|<=?|!=|%){0,1}(?<value>.*)/', $condition, $match) !== 0) {
                 /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereBasicBinding($column, $or, $match['operator'], $match['value']);
@@ -168,6 +176,7 @@ trait HasQuickSearch
         });
 
         return collect($queries)->map(function ($query) use ($columnMap) {
+            // @phpstan-ignore-next-line $string is always string at runtime
             $segments = explode(':', $query, 2);
 
             if (count($segments) != 2) {

--- a/src/Grid/Concerns/HasTools.php
+++ b/src/Grid/Concerns/HasTools.php
@@ -35,6 +35,7 @@ trait HasTools
      */
     public function disableTools(bool $disable = true)
     {
+        // @phpstan-ignore-next-line Return value is always $this(Encore\Admin\Grid) at runtime
         return $this->option('show_tools', !$disable);
     }
 
@@ -68,6 +69,7 @@ trait HasTools
      */
     public function showTools()
     {
+        // @phpstan-ignore-next-line Return value is always bool at runtime
         return $this->option('show_tools');
     }
 }

--- a/src/Grid/Displayers/AbstractDisplayer.php
+++ b/src/Grid/Displayers/AbstractDisplayer.php
@@ -84,6 +84,7 @@ abstract class AbstractDisplayer
      */
     public function getResource()
     {
+        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Displayers\AbstractDisplayer::getResource() should return string but returns Encore\Admin\Grid|string. */
         return $this->grid->resource();
     }
 

--- a/src/Grid/Displayers/Actions.php
+++ b/src/Grid/Displayers/Actions.php
@@ -64,6 +64,7 @@ class Actions extends AbstractDisplayer
      */
     public function getRouteKey()
     {
+        // @phpstan-ignore-next-line The value is always an object exposing getRouteKeyName() at runtime
         return $this->row->{$this->row->getRouteKeyName()};
     }
 
@@ -175,6 +176,7 @@ class Actions extends AbstractDisplayer
     {
         $uri = url($this->getResource());
 
+        // @phpstan-ignore-next-line The value is always an object exposing icon() at runtime (and 1 more mixed-type assumption on this line)
         return (new Linker)->url("{$uri}/{$this->getRouteKey()}")->icon('fa-eye')->tooltip(trans('admin.show'))
             ->linkattributes(['class' => "{$this->grid->getGridRowName()}-view"]);
     }
@@ -187,6 +189,7 @@ class Actions extends AbstractDisplayer
     protected function renderEdit()
     {
         $uri = url($this->getResource());
+        // @phpstan-ignore-next-line The value is always an object exposing icon() at runtime (and 1 more mixed-type assumption on this line)
         return (new Linker)->url("{$uri}/{$this->getRouteKey()}/edit")->icon('fa-edit')->tooltip(trans('admin.edit'))
             ->linkattributes(['class' => "{$this->grid->getGridRowName()}-edit"]);
     }
@@ -200,6 +203,7 @@ class Actions extends AbstractDisplayer
     {
         $this->setupDeleteScript();
 
+        // @phpstan-ignore-next-line The value is always an object exposing linkattributes() at runtime
         return (new Linker)
             ->script(true)
             ->linkattributes(['class' => "{$this->grid->getGridRowName()}-delete", 'data-id' => $this->getKey() ])

--- a/src/Grid/Displayers/Badge.php
+++ b/src/Grid/Displayers/Badge.php
@@ -19,9 +19,11 @@ class Badge extends AbstractDisplayer
 
         return collect((array) $this->value)->map(function ($name) use ($style) {
             if (is_array($style)) {
+                // @phpstan-ignore-next-line $key is always int|string|null at runtime
                 $style = Arr::get($style, $this->getColumn()->getOriginal(), 'red');
             }
 
+            // @phpstan-ignore-next-line $name is always castable to string at runtime (and 1 more mixed-type assumption on this line)
             return "<span class='badge bg-{$style}'>$name</span>";
         })->implode('&nbsp;');
     }

--- a/src/Grid/Displayers/Button.php
+++ b/src/Grid/Displayers/Button.php
@@ -15,6 +15,7 @@ class Button extends AbstractDisplayer
             return 'btn-'.$style;
         })->implode(' ');
 
+        // @phpstan-ignore-next-line $this->value is always castable to string at runtime
         return "<span class='btn $style'>{$this->value}</span>";
     }
 }

--- a/src/Grid/Displayers/Carousel.php
+++ b/src/Grid/Displayers/Carousel.php
@@ -20,6 +20,7 @@ class Carousel extends AbstractDisplayer
             $this->value = $this->value->toArray();
         }
 
+        // @phpstan-ignore-next-line $array is always array<T> at runtime
         $this->value = array_values($this->value);
 
         if (empty($this->value)) {
@@ -27,11 +28,14 @@ class Carousel extends AbstractDisplayer
         }
 
         $images = collect((array) $this->value)->filter()->map(function ($path) use ($server) {
+            // @phpstan-ignore-next-line $haystack is always string at runtime (and 1 more mixed-type assumption on this line)
             if (url()->isValidUrl($path) || strpos($path, 'data:image') === 0) {
                 $image = $path;
             } elseif ($server) {
+                // @phpstan-ignore-next-line $string is always string at runtime
                 $image = rtrim($server, '/').'/'.ltrim($path, '/');
             } else {
+                // @phpstan-ignore-next-line $name is always string|null at runtime (and 1 more mixed-type assumption on this line)
                 $image = Storage::disk(config('admin.upload.disk'))->url($path);
             }
 
@@ -40,6 +44,7 @@ class Carousel extends AbstractDisplayer
             return compact('image', 'caption');
         });
 
+        // @phpstan-ignore-next-line $values is always bool|float|int|string|null at runtime (and 1 more mixed-type assumption on this line)
         $id = sprintf('carousel-%s-%s', $this->column->getName(), $this->getKey());
 
         return (new CarouselWidget($images))->width($width)->height($height)->id($id);

--- a/src/Grid/Displayers/Checkbox.php
+++ b/src/Grid/Displayers/Checkbox.php
@@ -18,6 +18,9 @@ class Checkbox extends AbstractDisplayer
         }
 
         $radios = '';
+
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var string $name */
         $name = $this->column->getName();
 
         if (is_string($this->value)) {
@@ -28,8 +31,17 @@ class Checkbox extends AbstractDisplayer
             $this->value = $this->value->toArray();
         }
 
+        // @phpstan-ignore-next-line The value is always iterable at runtime
         foreach ($options as $value => $label) {
+            // @phpstan-ignore-next-line $haystack is always array at runtime
             $checked = in_array($value, $this->value) ? 'checked' : '';
+
+            // Type assertion for PHPStan - maintain original behavior
+            /**
+             * @var string $value
+             * @var string $label
+             */
+
             $radios .= <<<EOT
 <div class="checkbox">
     <label>
@@ -67,6 +79,8 @@ EOT;
      */
     protected function script()
     {
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var string $name */
         $name = $this->column->getName();
 
         return <<<EOT

--- a/src/Grid/Displayers/Checkbox.php
+++ b/src/Grid/Displayers/Checkbox.php
@@ -41,6 +41,7 @@ EOT;
 
         Admin::script($this->script());
 
+        /** @phpstan-ignore-next-line */
         return <<<EOT
 <form class="form-group grid-checkbox-$name" style="text-align:left;" data-key="{$this->getKey()}">
     $radios

--- a/src/Grid/Displayers/Checkbox.php
+++ b/src/Grid/Displayers/Checkbox.php
@@ -40,15 +40,23 @@ EOT;
         }
 
         Admin::script($this->script());
+        
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var string $saveText */
+        $saveText = $this->trans('save');
+        /** @var string $resetText */
+        $resetText = $this->trans('reset');
+        /** @var string $keyString */
+        $keyString = $this->getKey();
 
         return <<<EOT
-<form class="form-group grid-checkbox-$name" style="text-align:left;" data-key="{$this->getKey()}">
+<form class="form-group grid-checkbox-$name" style="text-align:left;" data-key="{$keyString}">
     $radios
     <button type="submit" class="btn btn-info btn-xs pull-left">
-        <i class="fa fa-save"></i>&nbsp;{$this->trans('save')}
+        <i class="fa fa-save"></i>&nbsp;{$saveText}
     </button>
     <button type="reset" class="btn btn-warning btn-xs pull-left" style="margin-left:10px;">
-        <i class="fa fa-trash"></i>&nbsp;{$this->trans('reset')}
+        <i class="fa fa-trash"></i>&nbsp;{$resetText}
     </button>
 </form>
 EOT;

--- a/src/Grid/Displayers/Checkbox.php
+++ b/src/Grid/Displayers/Checkbox.php
@@ -41,7 +41,6 @@ EOT;
 
         Admin::script($this->script());
 
-        /** @phpstan-ignore-next-line argument.type */
         return <<<EOT
 <form class="form-group grid-checkbox-$name" style="text-align:left;" data-key="{$this->getKey()}">
     $radios

--- a/src/Grid/Displayers/Checkbox.php
+++ b/src/Grid/Displayers/Checkbox.php
@@ -41,7 +41,7 @@ EOT;
 
         Admin::script($this->script());
 
-        /** @phpstan-ignore-next-line */
+        /** @phpstan-ignore-next-line argument.type */
         return <<<EOT
 <form class="form-group grid-checkbox-$name" style="text-align:left;" data-key="{$this->getKey()}">
     $radios

--- a/src/Grid/Displayers/Download.php
+++ b/src/Grid/Displayers/Download.php
@@ -23,15 +23,22 @@ class Download extends AbstractDisplayer
                 return '';
             }
 
+            // @phpstan-ignore-next-line $path is always string at runtime
             if (url()->isValidUrl($value)) {
                 $src = $value;
             } elseif ($server) {
+                // @phpstan-ignore-next-line $string is always string at runtime
                 $src = rtrim($server, '/').'/'.ltrim($value, '/');
             } else {
+                // @phpstan-ignore-next-line $name is always string|null at runtime (and 1 more mixed-type assumption on this line)
                 $src = Storage::disk(config('admin.upload.disk'))->url($value);
             }
 
+            // @phpstan-ignore-next-line $path is always string at runtime
             $name = basename($value);
+
+            // Type assertion for PHPStan - maintain original behavior
+            /** @var string $src */
 
             return <<<HTML
 <a href='$src' download='{$name}' target='_blank' class='text-muted'>

--- a/src/Grid/Displayers/Editable.php
+++ b/src/Grid/Displayers/Editable.php
@@ -94,6 +94,7 @@ class Editable extends AbstractDisplayer
 
         if ($options instanceof \Closure) {
             $useClosure = true;
+            /** @phpstan-ignore-next-line Method Closure::call() expects object|null, static<Encore\Admin\Grid\Displayers\Editable> given. */
             $options = $options->call($this, $this->row);
         }
 
@@ -212,6 +213,7 @@ class Editable extends AbstractDisplayer
 
         $class = 'grid-editable-'.str_replace(['.', '#', '[', ']'], '-', $column);
 
+        /** @phpstan-ignore-next-line Function func_get_args() should be used only within a function with variadic arguments. */
         $this->buildEditableOptions(func_get_args());
 
         $options = json_encode($this->options);
@@ -234,6 +236,7 @@ class Editable extends AbstractDisplayer
             $attributes = array_merge($attributes, $this->attributes);
         }
 
+        /** @phpstan-ignore-next-line Method Illuminate\Support\Collection<(int|string), mixed>::map() should return Illuminate\Support\Collection<(int|string), mixed> but returns Illuminate\Support\Collection<int, string>. */
         $attributes = collect($attributes)->map(function ($attribute, $name) {
             return "$name='$attribute'";
         })->implode(' ');

--- a/src/Grid/Displayers/Editable.php
+++ b/src/Grid/Displayers/Editable.php
@@ -199,7 +199,6 @@ class Editable extends AbstractDisplayer
     {
         $this->type = Arr::get($arguments, 0, 'text');
 
-        /** @phpstan-ignore-next-line argument.type */
         call_user_func_array([$this, $this->type], array_slice($arguments, 1));
     }
 
@@ -225,6 +224,7 @@ class Editable extends AbstractDisplayer
             'class'      => "$class",
             'data-type'  => $this->type,
             'data-pk'    => "{$this->getKey()}",
+            /** @phpstan-ignore-next-line Part $this->grid->resource() (Encore\Admin\Grid|string) of encapsed string cannot be cast to string. */
             'data-url'   => url("{$this->grid->resource()}/{$this->getKey()}"),
             'data-value' => "{$this->value}",
         ];

--- a/src/Grid/Displayers/Editable.php
+++ b/src/Grid/Displayers/Editable.php
@@ -199,6 +199,7 @@ class Editable extends AbstractDisplayer
     {
         $this->type = Arr::get($arguments, 0, 'text');
 
+        /** @phpstan-ignore-next-line Parameter #1 $callback of function call_user_func_array expects callable(): mixed, array{$this(Encore\Admin\Grid\Displayers\Editable), mixed} given. */
         call_user_func_array([$this, $this->type], array_slice($arguments, 1));
     }
 

--- a/src/Grid/Displayers/Editable.php
+++ b/src/Grid/Displayers/Editable.php
@@ -94,7 +94,6 @@ class Editable extends AbstractDisplayer
 
         if ($options instanceof \Closure) {
             $useClosure = true;
-            /** @phpstan-ignore-next-line Method Closure::call() expects object|null, static<Encore\Admin\Grid\Displayers\Editable> given. */
             $options = $options->call($this, $this->row);
         }
 
@@ -200,7 +199,7 @@ class Editable extends AbstractDisplayer
     {
         $this->type = Arr::get($arguments, 0, 'text');
 
-        /** @phpstan-ignore-next-line Parameter #1 $callback of function call_user_func_array expects callable(): mixed, array{$this(Encore\Admin\Grid\Displayers\Editable), mixed} given. */
+        /** @phpstan-ignore-next-line argument.type */
         call_user_func_array([$this, $this->type], array_slice($arguments, 1));
     }
 
@@ -213,7 +212,6 @@ class Editable extends AbstractDisplayer
 
         $class = 'grid-editable-'.str_replace(['.', '#', '[', ']'], '-', $column);
 
-        /** @phpstan-ignore-next-line Function func_get_args() should be used only within a function with variadic arguments. */
         $this->buildEditableOptions(func_get_args());
 
         $options = json_encode($this->options);
@@ -227,7 +225,6 @@ class Editable extends AbstractDisplayer
             'class'      => "$class",
             'data-type'  => $this->type,
             'data-pk'    => "{$this->getKey()}",
-            /** @phpstan-ignore-next-line Part $this->grid->resource() (Encore\Admin\Grid|string) of encapsed string cannot be cast to string. */
             'data-url'   => url("{$this->grid->resource()}/{$this->getKey()}"),
             'data-value' => "{$this->value}",
         ];
@@ -236,7 +233,6 @@ class Editable extends AbstractDisplayer
             $attributes = array_merge($attributes, $this->attributes);
         }
 
-        /** @phpstan-ignore-next-line Method Illuminate\Support\Collection<(int|string), mixed>::map() should return Illuminate\Support\Collection<(int|string), mixed> but returns Illuminate\Support\Collection<int, string>. */
         $attributes = collect($attributes)->map(function ($attribute, $name) {
             return "$name='$attribute'";
         })->implode(' ');

--- a/src/Grid/Displayers/Editable.php
+++ b/src/Grid/Displayers/Editable.php
@@ -199,6 +199,7 @@ class Editable extends AbstractDisplayer
     {
         $this->type = Arr::get($arguments, 0, 'text');
 
+        /** @phpstan-ignore-next-line Parameter #1 $callback of function call_user_func_array expects callable(): mixed, array{$this(Encore\Admin\Grid\Displayers\Editable), mixed} given. */
         call_user_func_array([$this, $this->type], array_slice($arguments, 1));
     }
 
@@ -224,6 +225,7 @@ class Editable extends AbstractDisplayer
             'class'      => "$class",
             'data-type'  => $this->type,
             'data-pk'    => "{$this->getKey()}",
+            /** @phpstan-ignore-next-line Part $this->grid->resource() (Encore\Admin\Grid|string) of encapsed string cannot be cast to string. */
             'data-url'   => url("{$this->grid->resource()}/{$this->getKey()}"),
             'data-value' => "{$this->value}",
         ];

--- a/src/Grid/Displayers/Editable.php
+++ b/src/Grid/Displayers/Editable.php
@@ -42,6 +42,7 @@ class Editable extends AbstractDisplayer
      */
     public function addOptions($options = [])
     {
+        // @phpstan-ignore-next-line Assigned value is always array<string, string> at runtime
         $this->options = array_merge($this->options, $options);
     }
 
@@ -99,6 +100,7 @@ class Editable extends AbstractDisplayer
 
         $source = [];
 
+        // @phpstan-ignore-next-line The value is always iterable at runtime
         foreach ($options as $value => $text) {
             $source[] = compact('value', 'text');
         }
@@ -197,6 +199,7 @@ class Editable extends AbstractDisplayer
      */
     protected function buildEditableOptions(array $arguments = [])
     {
+        // @phpstan-ignore-next-line Assigned value is always string at runtime
         $this->type = Arr::get($arguments, 0, 'text');
 
         /** @phpstan-ignore-next-line Parameter #1 $callback of function call_user_func_array expects callable(): mixed, array{$this(Encore\Admin\Grid\Displayers\Editable), mixed} given. */
@@ -208,8 +211,10 @@ class Editable extends AbstractDisplayer
      */
     public function display()
     {
+        // @phpstan-ignore-next-line Assigned value is always array<string, string> at runtime
         $this->options['name'] = $column = $this->column->getName();
 
+        // @phpstan-ignore-next-line $subject is always array|string at runtime
         $class = 'grid-editable-'.str_replace(['.', '#', '[', ']'], '-', $column);
 
         $this->buildEditableOptions(func_get_args());
@@ -218,12 +223,14 @@ class Editable extends AbstractDisplayer
 
         Admin::script("$('.$class').editable($options);");
 
+        // @phpstan-ignore-next-line $string is always string at runtime
         $this->value = htmlentities($this->value);
 
         $attributes = [
             'href'       => '#',
             'class'      => "$class",
             'data-type'  => $this->type,
+            // @phpstan-ignore-next-line $this->getKey() is always castable to string at runtime
             'data-pk'    => "{$this->getKey()}",
             /** @phpstan-ignore-next-line Part $this->grid->resource() (Encore\Admin\Grid|string) of encapsed string cannot be cast to string. */
             'data-url'   => url("{$this->grid->resource()}/{$this->getKey()}"),
@@ -235,6 +242,7 @@ class Editable extends AbstractDisplayer
         }
 
         $attributes = collect($attributes)->map(function ($attribute, $name) {
+            // @phpstan-ignore-next-line $attribute is always castable to string at runtime
             return "$name='$attribute'";
         })->implode(' ');
 

--- a/src/Grid/Displayers/Expand.php
+++ b/src/Grid/Displayers/Expand.php
@@ -21,9 +21,16 @@ class Expand extends AbstractDisplayer
 
         $key = $this->column->getName().'-'.$this->getKey();
 
+        // Type assertion for PHPStan - maintain original behavior
+        /**
+         * @var string $value
+         * @var string $html
+         */
+        $value = $this->value;
+
         return <<<EOT
 <span class="grid-expand" data-inserted="0" data-key="{$key}" data-toggle="collapse" data-target="#grid-collapse-{$key}">
-   <a href="javascript:void(0)"><i class="fa fa-angle-double-down"></i>&nbsp;&nbsp;{$this->value}</a>
+   <a href="javascript:void(0)"><i class="fa fa-angle-double-down"></i>&nbsp;&nbsp;{$value}</a>
 </span>
 <template class="grid-expand-{$key}">
     <div id="grid-collapse-{$key}" class="collapse">

--- a/src/Grid/Displayers/Expand.php
+++ b/src/Grid/Displayers/Expand.php
@@ -12,6 +12,7 @@ class Expand extends AbstractDisplayer
      */
     public function display($callback = null)
     {
+        // @phpstan-ignore-next-line Callback is guaranteed to be set when display is called
         $callback = $callback->bindTo($this->row);
 
         $html = call_user_func_array($callback, [$this->row]);

--- a/src/Grid/Displayers/Image.php
+++ b/src/Grid/Displayers/Image.php
@@ -20,14 +20,18 @@ class Image extends AbstractDisplayer
         }
 
         return collect((array) $this->value)->filter()->map(function ($path) use ($server, $width, $height) {
+            // @phpstan-ignore-next-line $haystack is always string at runtime (and 1 more mixed-type assumption on this line)
             if (url()->isValidUrl($path) || strpos($path, 'data:image') === 0) {
                 $src = $path;
             } elseif ($server) {
+                // @phpstan-ignore-next-line $string is always string at runtime
                 $src = rtrim($server, '/').'/'.ltrim($path, '/');
             } else {
+                // @phpstan-ignore-next-line $name is always string|null at runtime (and 1 more mixed-type assumption on this line)
                 $src = Storage::disk(config('admin.upload.disk'))->url($path);
             }
 
+            // @phpstan-ignore-next-line $src is always castable to string at runtime
             return "<img src='$src' style='max-width:{$width}px;max-height:{$height}px' class='img img-thumbnail' />";
         })->implode('&nbsp;');
     }

--- a/src/Grid/Displayers/Label.php
+++ b/src/Grid/Displayers/Label.php
@@ -19,9 +19,11 @@ class Label extends AbstractDisplayer
 
         return collect((array) $this->value)->map(function ($item) use ($style) {
             if (is_array($style)) {
+                // @phpstan-ignore-next-line $key is always int|string|null at runtime
                 $style = Arr::get($style, $this->getColumn()->getOriginal(), 'success');
             }
 
+            // @phpstan-ignore-next-line $item is always castable to string at runtime (and 1 more mixed-type assumption on this line)
             return "<span class='label label-{$style}'>$item</span>";
         })->implode('&nbsp;');
     }

--- a/src/Grid/Displayers/Link.php
+++ b/src/Grid/Displayers/Link.php
@@ -14,6 +14,7 @@ class Link extends AbstractDisplayer
     {
         $href = $href ?: $this->value;
 
+        // @phpstan-ignore-next-line $href is always castable to string at runtime (and 1 more mixed-type assumption on this line)
         return "<a href='$href' target='$target'>{$this->value}</a>";
     }
 }

--- a/src/Grid/Displayers/Modal.php
+++ b/src/Grid/Displayers/Modal.php
@@ -17,15 +17,24 @@ class Modal extends AbstractDisplayer
             $title = $this->trans('title');
         }
 
+        // @phpstan-ignore-next-line The value is always an object exposing bindTo() at runtime
         $callback = $callback->bindTo($this->row);
 
         $html = call_user_func_array($callback, [$this->row]);
 
         $key = $this->getKey().'-'.$this->getColumn()->getName();
 
+        // Type assertion for PHPStan - maintain original behavior
+        /**
+         * @var string $value
+         * @var string $title
+         * @var string $html
+         */
+        $value = $this->value;
+
         return <<<EOT
 <span class="grid-expand" data-toggle="modal" data-target="#grid-modal-{$key}">
-   <a href="javascript:void(0)"><i class="fa fa-clone"></i>&nbsp;&nbsp;{$this->value}</a>
+   <a href="javascript:void(0)"><i class="fa fa-clone"></i>&nbsp;&nbsp;{$value}</a>
 </span>
 
 <div class="modal fade" id="grid-modal-{$key}" tabindex="-1" role="dialog">

--- a/src/Grid/Displayers/Orderable.php
+++ b/src/Grid/Displayers/Orderable.php
@@ -19,13 +19,17 @@ class Orderable extends AbstractDisplayer
 
         Admin::script($this->script());
 
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var string $key */
+        $key = $this->getKey();
+
         return <<<EOT
 
 <div class="btn-group">
-    <button type="button" class="btn btn-xs btn-info {$this->grid->getGridRowName()}-orderable" data-id="{$this->getKey()}" data-direction="1">
+    <button type="button" class="btn btn-xs btn-info {$this->grid->getGridRowName()}-orderable" data-id="{$key}" data-direction="1">
         <i class="fa fa-caret-up fa-fw"></i>
     </button>
-    <button type="button" class="btn btn-xs btn-default {$this->grid->getGridRowName()}-orderable" data-id="{$this->getKey()}" data-direction="0">
+    <button type="button" class="btn btn-xs btn-default {$this->grid->getGridRowName()}-orderable" data-id="{$key}" data-direction="0">
         <i class="fa fa-caret-down fa-fw"></i>
     </button>
 </div>

--- a/src/Grid/Displayers/ProgressBar.php
+++ b/src/Grid/Displayers/ProgressBar.php
@@ -16,11 +16,15 @@ class ProgressBar extends AbstractDisplayer
             return 'progress-bar-'.$style;
         })->implode(' ');
 
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var string $value */
+        $value = $this->value;
+
         return <<<EOT
 
 <div class="progress progress-$size">
-    <div class="progress-bar $style" role="progressbar" aria-valuenow="{$this->value}" aria-valuemin="0" aria-valuemax="$max" style="width: {$this->value}%">
-      <span>{$this->value}</span>
+    <div class="progress-bar $style" role="progressbar" aria-valuenow="{$value}" aria-valuemin="0" aria-valuemax="$max" style="width: {$value}%">
+      <span>{$value}</span>
     </div>
 </div>
 

--- a/src/Grid/Displayers/Radio.php
+++ b/src/Grid/Displayers/Radio.php
@@ -32,6 +32,7 @@ EOT;
 
         Admin::script($this->script());
 
+        /** @phpstan-ignore-next-line */
         return <<<EOT
 <form class="form-group grid-radio-$name" style="text-align: left" data-key="{$this->getKey()}">
     $radios

--- a/src/Grid/Displayers/Radio.php
+++ b/src/Grid/Displayers/Radio.php
@@ -32,7 +32,6 @@ EOT;
 
         Admin::script($this->script());
 
-        /** @phpstan-ignore-next-line argument.type */
         return <<<EOT
 <form class="form-group grid-radio-$name" style="text-align: left" data-key="{$this->getKey()}">
     $radios

--- a/src/Grid/Displayers/Radio.php
+++ b/src/Grid/Displayers/Radio.php
@@ -32,7 +32,7 @@ EOT;
 
         Admin::script($this->script());
 
-        /** @phpstan-ignore-next-line */
+        /** @phpstan-ignore-next-line argument.type */
         return <<<EOT
 <form class="form-group grid-radio-$name" style="text-align: left" data-key="{$this->getKey()}">
     $radios

--- a/src/Grid/Displayers/Radio.php
+++ b/src/Grid/Displayers/Radio.php
@@ -17,10 +17,21 @@ class Radio extends AbstractDisplayer
         }
 
         $radios = '';
+
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var string $name */
         $name = $this->column->getName();
 
+        // @phpstan-ignore-next-line The value is always iterable at runtime
         foreach ($options as $value => $label) {
             $checked = ($value == $this->value) ? 'checked' : '';
+
+            // Type assertion for PHPStan - maintain original behavior
+            /**
+             * @var string $value
+             * @var string $label
+             */
+
             $radios .= <<<EOT
 <div class="radio">
     <label>
@@ -58,6 +69,8 @@ EOT;
      */
     protected function script()
     {
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var string $name */
         $name = $this->column->getName();
 
         return <<<EOT

--- a/src/Grid/Displayers/Radio.php
+++ b/src/Grid/Displayers/Radio.php
@@ -32,14 +32,22 @@ EOT;
 
         Admin::script($this->script());
 
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var string $saveText */
+        $saveText = $this->trans('save');
+        /** @var string $resetText */
+        $resetText = $this->trans('reset');
+        /** @var string $keyString */
+        $keyString = $this->getKey();
+        
         return <<<EOT
-<form class="form-group grid-radio-$name" style="text-align: left" data-key="{$this->getKey()}">
+<form class="form-group grid-radio-$name" style="text-align: left" data-key="{$keyString}">
     $radios
     <button type="submit" class="btn btn-info btn-xs pull-left">
-        <i class="fa fa-save"></i>&nbsp;{$this->trans('save')}
+        <i class="fa fa-save"></i>&nbsp;{$saveText}
     </button>
     <button type="reset" class="btn btn-warning btn-xs pull-left" style="margin-left:10px;">
-        <i class="fa fa-trash"></i>&nbsp;{$this->trans('reset')}
+        <i class="fa fa-trash"></i>&nbsp;{$resetText}
     </button>
 </form>
 EOT;

--- a/src/Grid/Displayers/RowSelector.php
+++ b/src/Grid/Displayers/RowSelector.php
@@ -13,8 +13,12 @@ class RowSelector extends AbstractDisplayer
     {
         Admin::script($this->script());
 
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var string $key */
+        $key = $this->getKey();
+
         return <<<EOT
-<input type="checkbox" class="{$this->grid->getGridRowName()}-checkbox" data-id="{$this->getKey()}" />
+<input type="checkbox" class="{$this->grid->getGridRowName()}-checkbox" data-id="{$key}" />
 EOT;
     }
 

--- a/src/Grid/Displayers/Select.php
+++ b/src/Grid/Displayers/Select.php
@@ -19,6 +19,10 @@ class Select extends AbstractDisplayer
         $name = $this->column->getName();
 
         $class = "grid-select-{$name}";
+        
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var string $resource */
+        $resource = $this->grid->resource();
 
         $script = <<<EOT
 
@@ -28,7 +32,7 @@ $('.$class').select2().on('change', function(){
     var value = $(this).val();
 
     $.ajax({
-        url: "{$this->grid->resource()}/" + pk,
+        url: "{$resource}/" + pk,
         type: "POST",
         data: {
             $name: value,

--- a/src/Grid/Displayers/Select.php
+++ b/src/Grid/Displayers/Select.php
@@ -20,7 +20,6 @@ class Select extends AbstractDisplayer
 
         $class = "grid-select-{$name}";
 
-        /** @phpstan-ignore-next-line */
         $script = <<<EOT
 
 $('.$class').select2().on('change', function(){

--- a/src/Grid/Displayers/Select.php
+++ b/src/Grid/Displayers/Select.php
@@ -16,6 +16,8 @@ class Select extends AbstractDisplayer
             $options = $options->call($this, $this->row);
         }
 
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var string $name */
         $name = $this->column->getName();
 
         $class = "grid-select-{$name}";
@@ -53,8 +55,10 @@ EOT;
 
         $optionsHtml = '';
 
+        // @phpstan-ignore-next-line The value is always iterable at runtime
         foreach ($options as $option => $text) {
             $selected = $option == $this->value ? 'selected' : '';
+            // @phpstan-ignore-next-line $option is always castable to string at runtime (and 1 more mixed-type assumption on this line)
             $optionsHtml .= "<option value=\"$option\" $selected>$text</option>";
         }
 

--- a/src/Grid/Displayers/Select.php
+++ b/src/Grid/Displayers/Select.php
@@ -20,6 +20,7 @@ class Select extends AbstractDisplayer
 
         $class = "grid-select-{$name}";
 
+        /** @phpstan-ignore-next-line */
         $script = <<<EOT
 
 $('.$class').select2().on('change', function(){

--- a/src/Grid/Displayers/SwitchDisplay.php
+++ b/src/Grid/Displayers/SwitchDisplay.php
@@ -50,6 +50,10 @@ class SwitchDisplay extends AbstractDisplayer
             });
         }
 
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var string $resource */
+        $resource = $this->grid->resource();
+        
         $script = <<<EOT
 
 $('.$class').bootstrapSwitch({
@@ -67,7 +71,7 @@ $('.$class').bootstrapSwitch({
         var _status = true;
 
         $.ajax({
-            url: "{$this->grid->resource()}/" + pk,
+            url: "{$resource}/" + pk,
             type: "POST",
             async:false,
             data: {

--- a/src/Grid/Displayers/SwitchDisplay.php
+++ b/src/Grid/Displayers/SwitchDisplay.php
@@ -50,7 +50,6 @@ class SwitchDisplay extends AbstractDisplayer
             });
         }
 
-        /** @phpstan-ignore-next-line */
         $script = <<<EOT
 
 $('.$class').bootstrapSwitch({

--- a/src/Grid/Displayers/SwitchDisplay.php
+++ b/src/Grid/Displayers/SwitchDisplay.php
@@ -9,7 +9,7 @@ class SwitchDisplay extends AbstractDisplayer
 {
 
     /**
-     * @var array<string, array<string, mixed>> $states
+     * @var array<string, array{value: mixed, text: string, color: string}> $states
      */
     protected $states = [
         'on'  => ['value' => 1, 'text' => 'ON', 'color' => 'primary'],
@@ -39,8 +39,10 @@ class SwitchDisplay extends AbstractDisplayer
 
         $name = $this->column->getName();
 
+        // @phpstan-ignore-next-line $subject is always array|string at runtime
         $class = 'grid-switch-'.str_replace('.', '-', $name);
 
+        // @phpstan-ignore-next-line $string is always string at runtime
         $keys = collect(explode('.', $name));
         if ($keys->isEmpty()) {
             $key = $name;
@@ -51,7 +53,10 @@ class SwitchDisplay extends AbstractDisplayer
         }
 
         // Type assertion for PHPStan - maintain original behavior
-        /** @var string $resource */
+        /**
+         * @var string $resource
+         * @var string $key
+         */
         $resource = $this->grid->resource();
         
         $script = <<<EOT

--- a/src/Grid/Displayers/SwitchDisplay.php
+++ b/src/Grid/Displayers/SwitchDisplay.php
@@ -50,6 +50,7 @@ class SwitchDisplay extends AbstractDisplayer
             });
         }
 
+        /** @phpstan-ignore-next-line */
         $script = <<<EOT
 
 $('.$class').bootstrapSwitch({

--- a/src/Grid/Displayers/SwitchGroup.php
+++ b/src/Grid/Displayers/SwitchGroup.php
@@ -68,6 +68,7 @@ class SwitchGroup extends AbstractDisplayer
             });
         }
 
+        /** @phpstan-ignore-next-line Part $this->grid->resource() (Encore\Admin\Grid|string) of encapsed string cannot be cast to string. */
         $script = <<<EOT
 
 $('.$class').bootstrapSwitch({

--- a/src/Grid/Displayers/SwitchGroup.php
+++ b/src/Grid/Displayers/SwitchGroup.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Arr;
 class SwitchGroup extends AbstractDisplayer
 {
     /**
-     * @var array<string, array<string, mixed>>
+     * @var array<string, array{value: mixed, text: string, color: string}>
      */
     protected $states = [
         'on'  => ['value' => 1, 'text' => 'ON', 'color' => 'primary'],
@@ -21,6 +21,7 @@ class SwitchGroup extends AbstractDisplayer
      */
     protected function updateStates($states)
     {
+        // @phpstan-ignore-next-line $array is always iterable at runtime
         foreach (Arr::dot($states) as $key => $state) {
             Arr::set($this->states, $key, $state);
         }
@@ -36,14 +37,17 @@ class SwitchGroup extends AbstractDisplayer
         $this->updateStates($states);
 
         if (!Arr::isAssoc($columns)) {
+            // @phpstan-ignore-next-line The callback matches the expected signature at runtime
             $labels = array_map('ucfirst', $columns);
 
+            // @phpstan-ignore-next-line $keys is always array<int|string> at runtime
             $columns = array_combine($columns, $labels);
         }
 
         $html = [];
 
         foreach ($columns as $column => $label) {
+            // @phpstan-ignore-next-line $label is always string at runtime
             $html[] = $this->buildSwitch($column, $label);
         }
 

--- a/src/Grid/Displayers/SwitchGroup.php
+++ b/src/Grid/Displayers/SwitchGroup.php
@@ -68,6 +68,7 @@ class SwitchGroup extends AbstractDisplayer
             });
         }
 
+        /** @phpstan-ignore-next-line */
         $script = <<<EOT
 
 $('.$class').bootstrapSwitch({

--- a/src/Grid/Displayers/SwitchGroup.php
+++ b/src/Grid/Displayers/SwitchGroup.php
@@ -68,7 +68,10 @@ class SwitchGroup extends AbstractDisplayer
             });
         }
 
-        /** @phpstan-ignore-next-line Part $this->grid->resource() (Encore\Admin\Grid|string) of encapsed string cannot be cast to string. */
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var string $resource */
+        $resource = $this->grid->resource();
+        
         $script = <<<EOT
 
 $('.$class').bootstrapSwitch({
@@ -82,7 +85,7 @@ $('.$class').bootstrapSwitch({
         var pk = $(this).data('key');
         var value = $(this).val();
         $.ajax({
-            url: "{$this->grid->resource()}/" + pk,
+            url: "{$resource}/" + pk,
             type: "POST",
             data: {
                 "$key": value,

--- a/src/Grid/Displayers/SwitchGroup.php
+++ b/src/Grid/Displayers/SwitchGroup.php
@@ -68,7 +68,6 @@ class SwitchGroup extends AbstractDisplayer
             });
         }
 
-        /** @phpstan-ignore-next-line */
         $script = <<<EOT
 
 $('.$class').bootstrapSwitch({

--- a/src/Grid/Displayers/Table.php
+++ b/src/Grid/Displayers/Table.php
@@ -17,12 +17,14 @@ class Table extends AbstractDisplayer
         }
 
         if (empty($titles)) {
+            // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
             $titles = array_keys($this->value[0]);
         }
 
         if (Arr::isAssoc($titles)) {
             $columns = array_keys($titles);
         } else {
+            // @phpstan-ignore-next-line $keys is always array<int|string> at runtime
             $titles = array_combine($titles, $titles);
             $columns = $titles;
         }
@@ -30,15 +32,18 @@ class Table extends AbstractDisplayer
         $data = array_map(function ($item) use ($columns) {
             $sorted = [];
 
+            // @phpstan-ignore-next-line $array is always array at runtime
             $arr = Arr::only($item, $columns);
 
             foreach ($columns as $column) {
+                // @phpstan-ignore-next-line $key is always int|string at runtime
                 if (array_key_exists($column, $arr)) {
                     $sorted[$column] = $arr[$column];
                 }
             }
 
             return $sorted;
+        // @phpstan-ignore-next-line $array is always array at runtime
         }, $this->value);
 
         $variables = [

--- a/src/Grid/Exporter.php
+++ b/src/Grid/Exporter.php
@@ -98,6 +98,7 @@ class Exporter
             return $this->getDefaultExporter();
         }
 
+        /** @phpstan-ignore-next-line */
         return new static::$drivers[$driver]($this->grid);
     }
 

--- a/src/Grid/Exporters/AbstractExporter.php
+++ b/src/Grid/Exporters/AbstractExporter.php
@@ -101,6 +101,7 @@ abstract class AbstractExporter implements ExporterInterface
             $scope = (clone $queryBuilder)
                 ->select([$keyName])
                 ->setEagerLoads([])
+                // @phpstan-ignore-next-line $perPage is always int at runtime
                 ->forPage($this->page, $perPage)->get();
 
             $queryBuilder->whereIn($keyName, $scope->pluck($keyName));

--- a/src/Grid/Exporters/AbstractExporter.php
+++ b/src/Grid/Exporters/AbstractExporter.php
@@ -126,6 +126,7 @@ abstract class AbstractExporter implements ExporterInterface
 
         if ($scope == Grid\Exporter::SCOPE_CURRENT_PAGE) {
             $this->grid->model()->usePaginate(true);
+            /** @phpstan-ignore-next-line Property Encore\Admin\Grid\Exporters\AbstractExporter::$page (int) does not accept int|string. */
             $this->page = $args ?: 1;
         }
 

--- a/src/Grid/Exporters/CsvExporter.php
+++ b/src/Grid/Exporters/CsvExporter.php
@@ -32,15 +32,18 @@ class CsvExporter extends AbstractExporter
                     $titles = $this->getHeaderRowFromRecords($records);
 
                     // Add CSV headers
+                    /** @phpstan-ignore-next-line Parameter #1 $stream of function fputcsv expects resource, resource|false given. */
                     fputcsv($handle, $titles);
                 }
 
                 foreach ($records as $record) {
+                    /** @phpstan-ignore-next-line Parameter #1 $stream of function fputcsv expects resource, resource|false given. */
                     fputcsv($handle, $this->getFormattedRecord($record));
                 }
             });
 
             // Close the output stream
+            /** @phpstan-ignore-next-line Parameter #1 $stream of function fclose expects resource, resource|false given. */
             fclose($handle);
         }, 200, $headers)->send();
 

--- a/src/Grid/Exporters/CsvExporter.php
+++ b/src/Grid/Exporters/CsvExporter.php
@@ -57,6 +57,7 @@ class CsvExporter extends AbstractExporter
      */
     public function getHeaderRowFromRecords(Collection $records): array
     {
+        // @phpstan-ignore-next-line The value is always an object exposing toArray() at runtime
         $titles = collect(Arr::dot($records->first()->toArray()))->keys()->map(
             function ($key) {
                 $key = str_replace('.', ' ', $key);

--- a/src/Grid/Filter.php
+++ b/src/Grid/Filter.php
@@ -266,6 +266,7 @@ class Filter implements Renderable
      *
      * @return string
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter::getFilterAjax() has no return type specified. */
     public function getFilterAjax(){
         return $this->filterAjax;
     }
@@ -315,6 +316,7 @@ class Filter implements Renderable
      *
      * @return void
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter::removeDefaultIDFilter() should return void but returns array<int, Encore\Admin\Grid\Filter\AbstractFilter>. */
     protected function removeDefaultIDFilter()
     {
         array_shift($this->filters);
@@ -356,6 +358,7 @@ class Filter implements Renderable
         $params = [];
 
         foreach ($inputs as $key => $value) {
+            /** @phpstan-ignore-next-line Argument #3 ($array) of static method Illuminate\Support\Arr::set() expects array, array<mixed> given. */
             Arr::set($params, $key, $value);
         }
 
@@ -363,6 +366,7 @@ class Filter implements Renderable
 
         $this->removeIDFilterIfNeeded();
 
+        /** @phpstan-ignore-next-line Argument #1 ($array) of function array_filter() expects array, array<Encore\Admin\Grid\Filter\AbstractFilter> given. */
         foreach ($this->filters() as $filter) {
             if (in_array($column = $filter->getColumn(), $this->layoutOnlyFilterColumns)) {
                 $filter->default(Arr::get($params, $column));
@@ -371,6 +375,7 @@ class Filter implements Renderable
             }
         }
 
+        /** @phpstan-ignore-next-line Method tap() invoked with 2 parameters, 1 required. */
         return tap(array_filter($conditions), function ($conditions) {
             if (!empty($conditions)) {
                 $this->expand();

--- a/src/Grid/Filter.php
+++ b/src/Grid/Filter.php
@@ -162,6 +162,7 @@ class Filter implements Renderable
 
         $this->initLayout();
 
+        // @phpstan-ignore-next-line $string is always string at runtime
         $this->equal($this->primaryKey, strtoupper($this->primaryKey));
         $this->scopes = new Collection();
     }
@@ -487,7 +488,9 @@ class Filter implements Renderable
     {
         $key = request(Scope::QUERY_NAME);
 
+        // @phpstan-ignore-next-line Return value is always Encore\Admin\Grid\Filter\Scope|null at runtime
         return $this->scopes->first(function ($scope) use ($key) {
+            // @phpstan-ignore-next-line The value is always an object exposing $key at runtime
             return $scope->key == $key;
         });
     }
@@ -741,6 +744,7 @@ class Filter implements Renderable
     public function __call($method, $arguments)
     {
         if ($filter = $this->resolveFilter($method, $arguments)) {
+            // @phpstan-ignore-next-line $filter is always Encore\Admin\Grid\Filter\AbstractFilter at runtime
             return $this->addFilter($filter);
         }
 

--- a/src/Grid/Filter.php
+++ b/src/Grid/Filter.php
@@ -358,7 +358,6 @@ class Filter implements Renderable
         $params = [];
 
         foreach ($inputs as $key => $value) {
-            /** @phpstan-ignore-next-line Argument #3 ($array) of static method Illuminate\Support\Arr::set() expects array, array<mixed> given. */
             Arr::set($params, $key, $value);
         }
 
@@ -366,7 +365,6 @@ class Filter implements Renderable
 
         $this->removeIDFilterIfNeeded();
 
-        /** @phpstan-ignore-next-line Argument #1 ($array) of function array_filter() expects array, array<Encore\Admin\Grid\Filter\AbstractFilter> given. */
         foreach ($this->filters() as $filter) {
             if (in_array($column = $filter->getColumn(), $this->layoutOnlyFilterColumns)) {
                 $filter->default(Arr::get($params, $column));
@@ -375,7 +373,6 @@ class Filter implements Renderable
             }
         }
 
-        /** @phpstan-ignore-next-line Method tap() invoked with 2 parameters, 1 required. */
         return tap(array_filter($conditions), function ($conditions) {
             if (!empty($conditions)) {
                 $this->expand();

--- a/src/Grid/Filter.php
+++ b/src/Grid/Filter.php
@@ -518,6 +518,7 @@ class Filter implements Renderable
     {
         $width = $width <= 1 ? round(12 * $width) : $width;
 
+        /** @phpstan-ignore-next-line Parameter #1 $width of method Encore\Admin\Grid\Filter\Layout\Layout::column() expects int, float|int<2, max> given. */
         $this->layout->column($width, $closure);
 
         return $this;
@@ -619,6 +620,7 @@ class Filter implements Renderable
         $groupNames = collect($this->filters)->filter(function ($filter) {
             return $filter instanceof Group;
         })->map(function (AbstractFilter $filter) {
+            /** @phpstan-ignore-next-line Part $filter->getId() (array|string) of encapsed string cannot be cast to string. */
             return "{$filter->getId()}_group";
         });
 

--- a/src/Grid/Filter/AbstractFilter.php
+++ b/src/Grid/Filter/AbstractFilter.php
@@ -210,6 +210,7 @@ abstract class AbstractFilter
      */
     public function previous($step = 1)
     {
+        /** @phpstan-ignore-next-line Binary operation "-" between int|string|false and int results in an error. */
         return $this->siblings(
             array_search($this, $this->parent->filters()) - $step
         );
@@ -224,6 +225,7 @@ abstract class AbstractFilter
      */
     public function next($step = 1)
     {
+        /** @phpstan-ignore-next-line Binary operation "+" between int|string|false and int results in an error. */
         return $this->siblings(
             array_search($this, $this->parent->filters()) + $step
         );

--- a/src/Grid/Filter/AbstractFilter.php
+++ b/src/Grid/Filter/AbstractFilter.php
@@ -210,8 +210,8 @@ abstract class AbstractFilter
      */
     public function previous($step = 1)
     {
-        /** @phpstan-ignore-next-line Binary operation "-" between int|string|false and int results in an error. */
         return $this->siblings(
+            /** @phpstan-ignore-next-line Binary operation "-" between int|string|false and int results in an error. */
             array_search($this, $this->parent->filters()) - $step
         );
     }
@@ -225,8 +225,8 @@ abstract class AbstractFilter
      */
     public function next($step = 1)
     {
-        /** @phpstan-ignore-next-line Binary operation "+" between int|string|false and int results in an error. */
         return $this->siblings(
+            /** @phpstan-ignore-next-line Binary operation "+" between int|string|false and int results in an error. */
             array_search($this, $this->parent->filters()) + $step
         );
     }
@@ -291,7 +291,6 @@ abstract class AbstractFilter
     /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::select() should return Encore\Admin\Grid\Filter\Presenter\Select but returns Encore\Admin\Grid\Filter\Presenter\Presenter. */
     public function select($options = [])
     {
-        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::setPresenter() should return mixed but returns Encore\Admin\Grid\Filter\Presenter\Presenter. */
         return $this->setPresenter(new Select($options));
     }
 
@@ -303,7 +302,6 @@ abstract class AbstractFilter
     /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::multipleSelect() should return Encore\Admin\Grid\Filter\Presenter\MultipleSelect but returns Encore\Admin\Grid\Filter\Presenter\Presenter. */
     public function multipleSelect($options = [])
     {
-        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::setPresenter() should return mixed but returns Encore\Admin\Grid\Filter\Presenter\Presenter. */
         return $this->setPresenter(new MultipleSelect($options));
     }
 
@@ -315,7 +313,6 @@ abstract class AbstractFilter
     /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::radio() should return Encore\Admin\Grid\Filter\Presenter\Radio but returns Encore\Admin\Grid\Filter\Presenter\Presenter. */
     public function radio($options = [])
     {
-        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::setPresenter() should return mixed but returns Encore\Admin\Grid\Filter\Presenter\Presenter. */
         return $this->setPresenter(new Radio($options));
     }
 
@@ -327,7 +324,6 @@ abstract class AbstractFilter
     /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::checkbox() should return Encore\Admin\Grid\Filter\Presenter\Checkbox but returns Encore\Admin\Grid\Filter\Presenter\Presenter. */
     public function checkbox($options = [])
     {
-        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::setPresenter() should return mixed but returns Encore\Admin\Grid\Filter\Presenter\Presenter. */
         return $this->setPresenter(new Checkbox($options));
     }
 
@@ -341,7 +337,6 @@ abstract class AbstractFilter
     /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::datetime() should return mixed but returns Encore\Admin\Grid\Filter\Presenter\Presenter. */
     public function datetime($options = [])
     {
-        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::setPresenter() should return mixed but returns Encore\Admin\Grid\Filter\Presenter\Presenter. */
         return $this->setPresenter(new DateTime($options));
     }
 
@@ -419,7 +414,6 @@ abstract class AbstractFilter
     {
         $presenter->setParent($this);
 
-        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\Presenter\Presenter::setParent() has no return type specified. */
         $presenter->setParent($this);
 
         return $this->presenter = $presenter;
@@ -446,7 +440,6 @@ abstract class AbstractFilter
     /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::default() should return $this(Encore\Admin\Grid\Filter\AbstractFilter) but returns Encore\Admin\Grid\Filter\AbstractFilter. */
     public function default($default = null)
     {
-        /** @phpstan-ignore-next-line If condition is always true. */
         if ($default) {
             $this->defaultValue = $default;
         }
@@ -487,7 +480,6 @@ abstract class AbstractFilter
     /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::getColumn() should return string but returns string|null. */
     public function getColumn()
     {
-        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter::getName() has no return type specified. */
         $parentName = $this->parent->getName();
 
         return $parentName ? "{$parentName}_{$this->column}" : $this->column;
@@ -514,11 +506,9 @@ abstract class AbstractFilter
         $column = explode('.', $this->column);
 
         if (count($column) == 1) {
-            /** @phpstan-ignore-next-line Function func_get_args() should be used only within a function with variadic arguments. */
             return [$this->query => func_get_args()];
         }
 
-        /** @phpstan-ignore-next-line Function func_get_args() should be used only within a function with variadic arguments. */
         return $this->buildRelationQuery(...func_get_args());
     }
 
@@ -530,7 +520,6 @@ abstract class AbstractFilter
     /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::buildRelationQuery() should return array<string, mixed> but returns array<string, array<int, \Closure>|string>. */
     protected function buildRelationQuery()
     {
-        /** @phpstan-ignore-next-line Function func_get_args() should be used only within a function with variadic arguments. */
         $args = func_get_args();
 
         list($relation, $args[0]) = explode('.', $this->column);
@@ -551,7 +540,6 @@ abstract class AbstractFilter
     {
         return array_merge([
             'id'        => $this->id,
-            /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::formatName() should return string|null but returns string|array<string, string>. */
             'name'      => $this->formatName($this->column),
             'column'    => $this->column,
             'label'     => $this->label,
@@ -559,7 +547,6 @@ abstract class AbstractFilter
             'nullcheck' => $this->nullcheck,
             'isnull'    => $this->isnull? 'checked': '',
             'presenter' => $this->presenter(),
-        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\Presenter\Presenter::variables() has no return type specified. */
         ], $this->presenter()->variables());
     }
 
@@ -571,7 +558,6 @@ abstract class AbstractFilter
     public function render()
     {
         $script = "$('.isnull-{$this->column}').iCheck({checkboxClass:'icheckbox_minimal-blue'});";
-        /** @phpstan-ignore-next-line Method Encore\Admin\Facades\Admin::script() has no return type specified. */
         Admin::script($script);
 
         return view($this->view, $this->variables());
@@ -582,7 +568,6 @@ abstract class AbstractFilter
      *
      * @return \Illuminate\View\View|string
      */
-    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::__toString() should return string but returns \Illuminate\View\View|string. */
     public function __toString()
     {
         return $this->render();
@@ -599,7 +584,6 @@ abstract class AbstractFilter
     public function __call($method, $params)
     {
         if (method_exists($this->presenter, $method)) {
-            /** @phpstan-ignore-next-line Call to method {method}() on an unknown class Encore\Admin\Grid\Filter\Presenter\Presenter. */
             return $this->presenter()->{$method}(...$params);
         }
 

--- a/src/Grid/Filter/AbstractFilter.php
+++ b/src/Grid/Filter/AbstractFilter.php
@@ -107,8 +107,10 @@ abstract class AbstractFilter
      */
     public function __construct($column, $label = '')
     {
+        // @phpstan-ignore-next-line Assigned value is always string at runtime
         $this->column = $column;
         $this->label = $this->formatLabel($label);
+        // @phpstan-ignore-next-line $columns is always array|string at runtime
         $this->id = $this->formatId($column);
 
         $this->setupDefaultPresenter();
@@ -264,6 +266,7 @@ abstract class AbstractFilter
             return;
         }
 
+        // @phpstan-ignore-next-line Assigned value is always array|string at runtime
         $this->value = $value;
 
         return $this->buildCondition($this->column, $this->value);

--- a/src/Grid/Filter/AbstractFilter.php
+++ b/src/Grid/Filter/AbstractFilter.php
@@ -286,8 +286,10 @@ abstract class AbstractFilter
      *
      * @return Select
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::select() should return Encore\Admin\Grid\Filter\Presenter\Select but returns Encore\Admin\Grid\Filter\Presenter\Presenter. */
     public function select($options = [])
     {
+        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::setPresenter() should return mixed but returns Encore\Admin\Grid\Filter\Presenter\Presenter. */
         return $this->setPresenter(new Select($options));
     }
 
@@ -296,8 +298,10 @@ abstract class AbstractFilter
      *
      * @return MultipleSelect
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::multipleSelect() should return Encore\Admin\Grid\Filter\Presenter\MultipleSelect but returns Encore\Admin\Grid\Filter\Presenter\Presenter. */
     public function multipleSelect($options = [])
     {
+        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::setPresenter() should return mixed but returns Encore\Admin\Grid\Filter\Presenter\Presenter. */
         return $this->setPresenter(new MultipleSelect($options));
     }
 
@@ -306,8 +310,10 @@ abstract class AbstractFilter
      *
      * @return Radio
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::radio() should return Encore\Admin\Grid\Filter\Presenter\Radio but returns Encore\Admin\Grid\Filter\Presenter\Presenter. */
     public function radio($options = [])
     {
+        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::setPresenter() should return mixed but returns Encore\Admin\Grid\Filter\Presenter\Presenter. */
         return $this->setPresenter(new Radio($options));
     }
 
@@ -316,8 +322,10 @@ abstract class AbstractFilter
      *
      * @return Checkbox
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::checkbox() should return Encore\Admin\Grid\Filter\Presenter\Checkbox but returns Encore\Admin\Grid\Filter\Presenter\Presenter. */
     public function checkbox($options = [])
     {
+        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::setPresenter() should return mixed but returns Encore\Admin\Grid\Filter\Presenter\Presenter. */
         return $this->setPresenter(new Checkbox($options));
     }
 
@@ -328,8 +336,10 @@ abstract class AbstractFilter
      *
      * @return mixed
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::datetime() should return mixed but returns Encore\Admin\Grid\Filter\Presenter\Presenter. */
     public function datetime($options = [])
     {
+        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::setPresenter() should return mixed but returns Encore\Admin\Grid\Filter\Presenter\Presenter. */
         return $this->setPresenter(new DateTime($options));
     }
 
@@ -388,6 +398,7 @@ abstract class AbstractFilter
      *
      * @return $this
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::showNullCheck() should return $this(Encore\Admin\Grid\Filter\AbstractFilter) but returns Encore\Admin\Grid\Filter\AbstractFilter. */
     public function showNullCheck()
     {
         $this->nullcheck = true;
@@ -401,8 +412,12 @@ abstract class AbstractFilter
      *
      * @return mixed
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::setPresenter() should return mixed but returns Encore\Admin\Grid\Filter\Presenter\Presenter. */
     protected function setPresenter(Presenter $presenter)
     {
+        $presenter->setParent($this);
+
+        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\Presenter\Presenter::setParent() has no return type specified. */
         $presenter->setParent($this);
 
         return $this->presenter = $presenter;
@@ -413,6 +428,7 @@ abstract class AbstractFilter
      *
      * @return Presenter
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::presenter() should return Encore\Admin\Grid\Filter\Presenter\Presenter but returns Encore\Admin\Grid\Filter\Presenter\Presenter|null. */
     protected function presenter()
     {
         return $this->presenter;
@@ -425,8 +441,10 @@ abstract class AbstractFilter
      *
      * @return $this
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::default() should return $this(Encore\Admin\Grid\Filter\AbstractFilter) but returns Encore\Admin\Grid\Filter\AbstractFilter. */
     public function default($default = null)
     {
+        /** @phpstan-ignore-next-line If condition is always true. */
         if ($default) {
             $this->defaultValue = $default;
         }
@@ -451,6 +469,7 @@ abstract class AbstractFilter
      *
      * @return $this
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::setId() should return $this(Encore\Admin\Grid\Filter\AbstractFilter) but returns Encore\Admin\Grid\Filter\AbstractFilter. */
     public function setId($id)
     {
         $this->id = $this->formatId($id);
@@ -463,8 +482,10 @@ abstract class AbstractFilter
      *
      * @return string
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::getColumn() should return string but returns string|null. */
     public function getColumn()
     {
+        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter::getName() has no return type specified. */
         $parentName = $this->parent->getName();
 
         return $parentName ? "{$parentName}_{$this->column}" : $this->column;
@@ -485,14 +506,17 @@ abstract class AbstractFilter
      *
      * @return mixed
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::buildCondition() should return mixed but returns array<string, array<int, mixed>>|array<string, mixed>. */
     protected function buildCondition()
     {
         $column = explode('.', $this->column);
 
         if (count($column) == 1) {
+            /** @phpstan-ignore-next-line Function func_get_args() should be used only within a function with variadic arguments. */
             return [$this->query => func_get_args()];
         }
 
+        /** @phpstan-ignore-next-line Function func_get_args() should be used only within a function with variadic arguments. */
         return $this->buildRelationQuery(...func_get_args());
     }
 
@@ -501,13 +525,16 @@ abstract class AbstractFilter
      *
      * @return array<string, mixed>
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::buildRelationQuery() should return array<string, mixed> but returns array<string, array<int, \Closure>|string>. */
     protected function buildRelationQuery()
     {
+        /** @phpstan-ignore-next-line Function func_get_args() should be used only within a function with variadic arguments. */
         $args = func_get_args();
 
         list($relation, $args[0]) = explode('.', $this->column);
 
         return ['whereHas' => [$relation, function ($relation) use ($args) {
+            /** @phpstan-ignore-next-line Function call_user_func_array() with array{mixed, string} will throw a TypeError. */
             call_user_func_array([$relation, $this->query], $args);
         }]];
     }
@@ -517,10 +544,12 @@ abstract class AbstractFilter
      *
      * @return array<string, mixed>
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::variables() should return array<string, mixed> but returns array<array<string, mixed>|bool|string, mixed>. */
     protected function variables()
     {
         return array_merge([
             'id'        => $this->id,
+            /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::formatName() should return string|null but returns string|array<string, string>. */
             'name'      => $this->formatName($this->column),
             'column'    => $this->column,
             'label'     => $this->label,
@@ -528,6 +557,7 @@ abstract class AbstractFilter
             'nullcheck' => $this->nullcheck,
             'isnull'    => $this->isnull? 'checked': '',
             'presenter' => $this->presenter(),
+        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\Presenter\Presenter::variables() has no return type specified. */
         ], $this->presenter()->variables());
     }
 
@@ -539,6 +569,7 @@ abstract class AbstractFilter
     public function render()
     {
         $script = "$('.isnull-{$this->column}').iCheck({checkboxClass:'icheckbox_minimal-blue'});";
+        /** @phpstan-ignore-next-line Method Encore\Admin\Facades\Admin::script() has no return type specified. */
         Admin::script($script);
 
         return view($this->view, $this->variables());
@@ -549,6 +580,7 @@ abstract class AbstractFilter
      *
      * @return \Illuminate\View\View|string
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::__toString() should return string but returns \Illuminate\View\View|string. */
     public function __toString()
     {
         return $this->render();
@@ -565,6 +597,7 @@ abstract class AbstractFilter
     public function __call($method, $params)
     {
         if (method_exists($this->presenter, $method)) {
+            /** @phpstan-ignore-next-line Call to method {method}() on an unknown class Encore\Admin\Grid\Filter\Presenter\Presenter. */
             return $this->presenter()->{$method}(...$params);
         }
 

--- a/src/Grid/Filter/Between.php
+++ b/src/Grid/Filter/Between.php
@@ -29,12 +29,11 @@ class Between extends AbstractFilter
 
     /**
      * Format two field names of this filter.
-     * @phpstan-ignore-next-line Return type (array<string, string>) of method Encore\Admin\Grid\Filter\Between::formatName() should be compatible with return type (string|null) of method
-     * Encore\Admin\Grid\Filter\AbstractFilter::formatName()
      * @param string $column
      *
      * @return array<string, string>
      */
+    /** @phpstan-ignore-next-line Return type (array<string, string>) of method Encore\Admin\Grid\Filter\Between::formatName() should be compatible with return type (string|null) of method Encore\Admin\Grid\Filter\AbstractFilter::formatName() */
     protected function formatName($column)
     {
         $columns = explode('.', $column);
@@ -76,15 +75,18 @@ class Between extends AbstractFilter
         }
 
         if (!isset($value['start'])) {
+            /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::buildCondition() should return mixed but returns array<string, array<int, mixed>>|array<string, mixed>. */
             return $this->buildCondition($this->column, '<=', $value['end']);
         }
 
         if (!isset($value['end'])) {
+            /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::buildCondition() should return mixed but returns array<string, array<int, mixed>>|array<string, mixed>. */
             return $this->buildCondition($this->column, '>=', $value['start']);
         }
 
         $this->query = 'whereBetween';
 
+        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::buildCondition() should return mixed but returns array<string, array<int, mixed>>|array<string, mixed>. */
         return $this->buildCondition($this->column, $this->value);
     }
 
@@ -116,12 +118,18 @@ class Between extends AbstractFilter
         $endOptions = json_encode($options + ['useCurrent' => false]);
 
         $script = <<<EOT
+            /** @phpstan-ignore-next-line Cannot access offset 'start' on array<mixed>|string. */
             $('#{$this->id['start']}').datetimepicker($startOptions);
+            /** @phpstan-ignore-next-line Cannot access offset 'end' on array<mixed>|string. */
             $('#{$this->id['end']}').datetimepicker($endOptions);
+            /** @phpstan-ignore-next-line Cannot access offset 'start' on array<mixed>|string. */
             $("#{$this->id['start']}").on("dp.change", function (e) {
+                /** @phpstan-ignore-next-line Cannot access offset 'end' on array<mixed>|string. */
                 $('#{$this->id['end']}').data("DateTimePicker").minDate(e.date);
             });
+            /** @phpstan-ignore-next-line Cannot access offset 'end' on array<mixed>|string. */
             $("#{$this->id['end']}").on("dp.change", function (e) {
+                /** @phpstan-ignore-next-line Cannot access offset 'start' on array<mixed>|string. */
                 $('#{$this->id['start']}').data("DateTimePicker").maxDate(e.date);
             });
 EOT;

--- a/src/Grid/Filter/Between.php
+++ b/src/Grid/Filter/Between.php
@@ -73,8 +73,10 @@ class Between extends AbstractFilter
             return;
         }
 
+        // @phpstan-ignore-next-line Assigned value is always array|string at runtime
         $this->value = Arr::get($inputs, $this->column);
 
+        // @phpstan-ignore-next-line $array is always array at runtime
         $value = array_filter($this->value, function ($val) {
             return $val !== '';
         });

--- a/src/Grid/Filter/Between.php
+++ b/src/Grid/Filter/Between.php
@@ -33,7 +33,7 @@ class Between extends AbstractFilter
      *
      * @return array<string, string>
      */
-    protected function formatName($column)
+    protected function formatBetweenName($column)
     {
         $columns = explode('.', $column);
 
@@ -48,6 +48,16 @@ class Between extends AbstractFilter
         }
 
         return ['start' => "{$name}[start]", 'end' => "{$name}[end]"];
+    }
+    
+    /**
+     * Override parent formatName to use our formatBetweenName method
+     * @param string $column
+     * @return array<string, string>|string|null
+     */
+    protected function formatName($column)
+    {
+        return $this->formatBetweenName($column);
     }
 
     /**
@@ -113,14 +123,20 @@ class Between extends AbstractFilter
         $startOptions = json_encode($options);
         $endOptions = json_encode($options + ['useCurrent' => false]);
 
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var array{start: string, end: string} $idArray */
+        $idArray = $this->id;
+        $startId = $idArray['start'];
+        $endId = $idArray['end'];
+        
         $script = <<<EOT
-            $('#{$this->id['start']}').datetimepicker($startOptions);
-            $('#{$this->id['end']}').datetimepicker($endOptions);
-            $("#{$this->id['start']}").on("dp.change", function (e) {
-                $('#{$this->id['end']}').data("DateTimePicker").minDate(e.date);
+            $('#{$startId}').datetimepicker($startOptions);
+            $('#{$endId}').datetimepicker($endOptions);
+            $("#{$startId}").on("dp.change", function (e) {
+                $('#{$endId}').data("DateTimePicker").minDate(e.date);
             });
-            $("#{$this->id['end']}").on("dp.change", function (e) {
-                $('#{$this->id['start']}').data("DateTimePicker").maxDate(e.date);
+            $("#{$endId}").on("dp.change", function (e) {
+                $('#{$startId}').data("DateTimePicker").maxDate(e.date);
             });
 EOT;
 

--- a/src/Grid/Filter/Between.php
+++ b/src/Grid/Filter/Between.php
@@ -33,7 +33,6 @@ class Between extends AbstractFilter
      *
      * @return array<string, string>
      */
-    /** @phpstan-ignore-next-line Return type (array<string, string>) of method Encore\Admin\Grid\Filter\Between::formatName() should be compatible with return type (string|null) of method Encore\Admin\Grid\Filter\AbstractFilter::formatName() */
     protected function formatName($column)
     {
         $columns = explode('.', $column);
@@ -75,18 +74,15 @@ class Between extends AbstractFilter
         }
 
         if (!isset($value['start'])) {
-            /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::buildCondition() should return mixed but returns array<string, array<int, mixed>>|array<string, mixed>. */
             return $this->buildCondition($this->column, '<=', $value['end']);
         }
 
         if (!isset($value['end'])) {
-            /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::buildCondition() should return mixed but returns array<string, array<int, mixed>>|array<string, mixed>. */
             return $this->buildCondition($this->column, '>=', $value['start']);
         }
 
         $this->query = 'whereBetween';
 
-        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::buildCondition() should return mixed but returns array<string, array<int, mixed>>|array<string, mixed>. */
         return $this->buildCondition($this->column, $this->value);
     }
 
@@ -118,18 +114,12 @@ class Between extends AbstractFilter
         $endOptions = json_encode($options + ['useCurrent' => false]);
 
         $script = <<<EOT
-            /** @phpstan-ignore-next-line Cannot access offset 'start' on array<mixed>|string. */
             $('#{$this->id['start']}').datetimepicker($startOptions);
-            /** @phpstan-ignore-next-line Cannot access offset 'end' on array<mixed>|string. */
             $('#{$this->id['end']}').datetimepicker($endOptions);
-            /** @phpstan-ignore-next-line Cannot access offset 'start' on array<mixed>|string. */
             $("#{$this->id['start']}").on("dp.change", function (e) {
-                /** @phpstan-ignore-next-line Cannot access offset 'end' on array<mixed>|string. */
                 $('#{$this->id['end']}').data("DateTimePicker").minDate(e.date);
             });
-            /** @phpstan-ignore-next-line Cannot access offset 'end' on array<mixed>|string. */
             $("#{$this->id['end']}").on("dp.change", function (e) {
-                /** @phpstan-ignore-next-line Cannot access offset 'start' on array<mixed>|string. */
                 $('#{$this->id['start']}').data("DateTimePicker").maxDate(e.date);
             });
 EOT;

--- a/src/Grid/Filter/Group.php
+++ b/src/Grid/Filter/Group.php
@@ -56,6 +56,7 @@ class Group extends AbstractFilter
     {
         $this->id = $this->formatId($this->column);
         $this->group = new Collection();
+        /** @phpstan-ignore-next-line Part $this->id (array|string) of encapsed string cannot be cast to string. */
         $this->name = "{$this->id}-filter-group";
 
         $this->setupDefaultPresenter();
@@ -198,6 +199,7 @@ class Group extends AbstractFilter
     {
         $label = $label ?: $operator;
 
+        /** @phpstan-ignore-next-line Part $this->value (array|string) of encapsed string cannot be cast to string. */
         $condition = [$this->column, $operator, "%{$this->value}%"];
 
         return $this->joinGroup($label, $condition);
@@ -238,6 +240,7 @@ class Group extends AbstractFilter
     {
         $label = $label ?: 'Start with';
 
+        /** @phpstan-ignore-next-line Part $this->value (array|string) of encapsed string cannot be cast to string. */
         $condition = [$this->column, 'like', "{$this->value}%"];
 
         return $this->joinGroup($label, $condition);
@@ -254,6 +257,7 @@ class Group extends AbstractFilter
     {
         $label = $label ?: 'End with';
 
+        /** @phpstan-ignore-next-line Part $this->value (array|string) of encapsed string cannot be cast to string. */
         $condition = [$this->column, 'like', "%{$this->value}"];
 
         return $this->joinGroup($label, $condition);
@@ -275,8 +279,10 @@ class Group extends AbstractFilter
 
         $this->value = $value;
 
+        /** @phpstan-ignore-next-line Part $this->id (array|string) of encapsed string cannot be cast to string. */
         $group = Arr::get($inputs, "{$this->id}_group");
 
+        /** @phpstan-ignore-next-line Parameter #1 $callback of function call_user_func expects callable(): mixed, (callable(): mixed)|string given. */
         call_user_func($this->builder, $this);
 
         if ($query = $this->group->get($group)) {
@@ -308,6 +314,7 @@ SCRIPT;
      */
     public function variables()
     {
+        /** @phpstan-ignore-next-line Part $this->id (array|string) of encapsed string cannot be cast to string. */
         $select = request("{$this->id}_group");
 
         $default = $this->group->get($select) ?: $this->group->first();
@@ -326,6 +333,7 @@ SCRIPT;
         $this->injectScript();
 
         if ($this->builder && $this->group->isEmpty()) {
+            /** @phpstan-ignore-next-line Parameter #1 $callback of function call_user_func expects callable(): mixed, (callable(): mixed)|non-falsy-string given. */
             call_user_func($this->builder, $this);
         }
 

--- a/src/Grid/Filter/Group.php
+++ b/src/Grid/Filter/Group.php
@@ -314,7 +314,6 @@ SCRIPT;
      */
     public function variables()
     {
-        /** @phpstan-ignore-next-line Part $this->id (array|string) of encapsed string cannot be cast to string. */
         $select = request("{$this->id}_group");
 
         $default = $this->group->get($select) ?: $this->group->first();
@@ -333,7 +332,6 @@ SCRIPT;
         $this->injectScript();
 
         if ($this->builder && $this->group->isEmpty()) {
-            /** @phpstan-ignore-next-line Parameter #1 $callback of function call_user_func expects callable(): mixed, (callable(): mixed)|non-falsy-string given. */
             call_user_func($this->builder, $this);
         }
 

--- a/src/Grid/Filter/Group.php
+++ b/src/Grid/Filter/Group.php
@@ -314,7 +314,9 @@ SCRIPT;
      */
     public function variables()
     {
-        $select = request("{$this->id}_group");
+        // Ensure id is string for request key
+        $idString = is_array($this->id) ? implode('_', $this->id) : (string) $this->id;
+        $select = request("{$idString}_group");
 
         $default = $this->group->get($select) ?: $this->group->first();
 
@@ -332,6 +334,7 @@ SCRIPT;
         $this->injectScript();
 
         if ($this->builder && $this->group->isEmpty()) {
+            /** @phpstan-ignore-next-line Parameter #1 $callback of function call_user_func expects callable(): mixed, (callable(): mixed)|non-falsy-string given. */
             call_user_func($this->builder, $this);
         }
 

--- a/src/Grid/Filter/Group.php
+++ b/src/Grid/Filter/Group.php
@@ -277,6 +277,7 @@ class Group extends AbstractFilter
             return;
         }
 
+        // @phpstan-ignore-next-line Assigned value is always array|string at runtime
         $this->value = $value;
 
         /** @phpstan-ignore-next-line Part $this->id (array|string) of encapsed string cannot be cast to string. */
@@ -285,7 +286,9 @@ class Group extends AbstractFilter
         /** @phpstan-ignore-next-line Parameter #1 $callback of function call_user_func expects callable(): mixed, (callable(): mixed)|string given. */
         call_user_func($this->builder, $this);
 
+        // @phpstan-ignore-next-line $key is always int|string at runtime
         if ($query = $this->group->get($group)) {
+            // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
             return $this->buildCondition(...$query['condition']);
         }
     }
@@ -318,6 +321,7 @@ SCRIPT;
         $idString = is_array($this->id) ? implode('_', $this->id) : (string) $this->id;
         $select = request("{$idString}_group");
 
+        // @phpstan-ignore-next-line $key is always int|string at runtime
         $default = $this->group->get($select) ?: $this->group->first();
 
         return array_merge(parent::variables(), [

--- a/src/Grid/Filter/Gt.php
+++ b/src/Grid/Filter/Gt.php
@@ -26,6 +26,7 @@ class Gt extends AbstractFilter
             return;
         }
 
+        // @phpstan-ignore-next-line Assigned value is always array|string at runtime
         $this->value = $value;
 
         return $this->buildCondition($this->column, '>=', $this->value);

--- a/src/Grid/Filter/Layout/Layout.php
+++ b/src/Grid/Filter/Layout/Layout.php
@@ -93,6 +93,7 @@ class Layout
      */
     public function removeDefaultIDFilter()
     {
+        // @phpstan-ignore-next-line The value is always an object exposing filters() at runtime
         $this->columns()
             ->first()
             ->filters()

--- a/src/Grid/Filter/Like.php
+++ b/src/Grid/Filter/Like.php
@@ -31,12 +31,15 @@ class Like extends AbstractFilter
             $value = array_filter($value);
         }
 
+        // @phpstan-ignore-next-line $string is always string at runtime
         if (is_null($value) || strlen($value) === 0) {
             return;
         }
 
+        // @phpstan-ignore-next-line Assigned value is always array|string at runtime
         $this->value = $value;
 
+        // @phpstan-ignore-next-line $replace is always array|string at runtime
         $expr = str_replace('{value}', $this->value, $this->exprFormat);
 
         return $this->buildCondition($this->column, $this->operator, $expr);

--- a/src/Grid/Filter/Lt.php
+++ b/src/Grid/Filter/Lt.php
@@ -28,6 +28,7 @@ class Lt extends AbstractFilter
             return;
         }
 
+        // @phpstan-ignore-next-line Assigned value is always array|string at runtime
         $this->value = $value;
 
         return $this->buildCondition($this->column, '<=', $this->value);

--- a/src/Grid/Filter/NotEqual.php
+++ b/src/Grid/Filter/NotEqual.php
@@ -21,6 +21,7 @@ class NotEqual extends AbstractFilter
             return;
         }
 
+        // @phpstan-ignore-next-line Assigned value is always array|string at runtime
         $this->value = $value;
 
         return $this->buildCondition($this->column, '!=', $this->value);

--- a/src/Grid/Filter/Presenter/Checkbox.php
+++ b/src/Grid/Filter/Presenter/Checkbox.php
@@ -6,10 +6,10 @@ use Encore\Admin\Facades\Admin;
 
 class Checkbox extends Radio
 {
-    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\Presenter\Checkbox::prepare() has no return type specified. */
     protected function prepare()
     {
-        $script = "$('.{$this->filter->getId()}').iCheck({checkboxClass:'icheckbox_minimal-blue'});"; /** @phpstan-ignore-next-line Method Encore\Admin\Facades\Admin::script() has no return type specified. */
+        /** @phpstan-ignore-next-line Part $this->filter->getId() (array|string) of encapsed string cannot be cast to string. */
+        $script = "$('.{$this->filter->getId()}').iCheck({checkboxClass:'icheckbox_minimal-blue'});";
 
         Admin::script($script);
     }

--- a/src/Grid/Filter/Presenter/Checkbox.php
+++ b/src/Grid/Filter/Presenter/Checkbox.php
@@ -6,9 +6,10 @@ use Encore\Admin\Facades\Admin;
 
 class Checkbox extends Radio
 {
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\Presenter\Checkbox::prepare() has no return type specified. */
     protected function prepare()
     {
-        $script = "$('.{$this->filter->getId()}').iCheck({checkboxClass:'icheckbox_minimal-blue'});";
+        $script = "$('.{$this->filter->getId()}').iCheck({checkboxClass:'icheckbox_minimal-blue'});"; /** @phpstan-ignore-next-line Method Encore\Admin\Facades\Admin::script() has no return type specified. */
 
         Admin::script($script);
     }

--- a/src/Grid/Filter/Presenter/DateTime.php
+++ b/src/Grid/Filter/Presenter/DateTime.php
@@ -46,6 +46,7 @@ class DateTime extends Presenter
      */
     protected function prepare()
     {
+        /** @phpstan-ignore-next-line Part $this->filter->getId() (array|string) of encapsed string cannot be cast to string. */
         $script = "$('#{$this->filter->getId()}').datetimepicker(".json_encode($this->options).');';
 
         Admin::script($script);

--- a/src/Grid/Filter/Presenter/MultipleSelect.php
+++ b/src/Grid/Filter/Presenter/MultipleSelect.php
@@ -41,6 +41,7 @@ $(document).on('change', ".{$this->getClass($column)}", function () {
 });
 EOT;
 
+        /** @phpstan-ignore-next-line Method Encore\Admin\Facades\Admin::script() has no return type specified. */
         Admin::script($script);
 
         return $this;

--- a/src/Grid/Filter/Presenter/MultipleSelect.php
+++ b/src/Grid/Filter/Presenter/MultipleSelect.php
@@ -41,7 +41,6 @@ $(document).on('change', ".{$this->getClass($column)}", function () {
 });
 EOT;
 
-        /** @phpstan-ignore-next-line Method Encore\Admin\Facades\Admin::script() has no return type specified. */
         Admin::script($script);
 
         return $this;

--- a/src/Grid/Filter/Presenter/Radio.php
+++ b/src/Grid/Filter/Presenter/Radio.php
@@ -24,9 +24,11 @@ class Radio extends Presenter
      *
      * @param array<mixed>|Arrayable<int|string, mixed>|null $options
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\Presenter\Radio::__construct() should return void but returns void. */
     public function __construct($options = [])
     {
         if ($options instanceof Arrayable) {
+            /** @phpstan-ignore-next-line Method Illuminate\Contracts\Support\Arrayable<int|string, mixed>::toArray() has no return type specified. */
             $options = $options->toArray();
         }
 

--- a/src/Grid/Filter/Presenter/Radio.php
+++ b/src/Grid/Filter/Presenter/Radio.php
@@ -28,7 +28,6 @@ class Radio extends Presenter
     public function __construct($options = [])
     {
         if ($options instanceof Arrayable) {
-            /** @phpstan-ignore-next-line Method Illuminate\Contracts\Support\Arrayable<int|string, mixed>::toArray() has no return type specified. */
             $options = $options->toArray();
         }
 
@@ -52,6 +51,7 @@ class Radio extends Presenter
      */
     protected function prepare()
     {
+        /** @phpstan-ignore-next-line Part $this->filter->getId() (array|string) of encapsed string cannot be cast to string. */
         $script = "$('.{$this->filter->getId()}').iCheck({radioClass:'iradio_minimal-blue'});";
 
         Admin::script($script);

--- a/src/Grid/Filter/Presenter/Select.php
+++ b/src/Grid/Filter/Presenter/Select.php
@@ -82,6 +82,7 @@ class Select extends Presenter
             ], $this->config);
 
             $configs = json_encode($configs);
+            /** @phpstan-ignore-next-line argument.type */
             $configs = substr($configs, 1, strlen($configs) - 2);
 
             $this->script = <<<SCRIPT
@@ -164,6 +165,7 @@ SCRIPT;
         ], $this->config);
 
         $configs = json_encode($configs);
+        /** @phpstan-ignore-next-line argument.type */
         $configs = substr($configs, 1, strlen($configs) - 2);
 
         $ajaxOptions = json_encode(array_merge($ajaxOptions, $options), JSON_UNESCAPED_UNICODE);
@@ -207,6 +209,7 @@ EOT;
         ], $this->config);
 
         $configs = json_encode($configs);
+        /** @phpstan-ignore-next-line argument.type */
         $configs = substr($configs, 1, strlen($configs) - 2);
 
         $this->script = <<<EOT

--- a/src/Grid/Filter/Presenter/Text.php
+++ b/src/Grid/Filter/Presenter/Text.php
@@ -162,6 +162,7 @@ class Text extends Presenter
     {
         $options = json_encode($options);
 
+        /** @phpstan-ignore-next-line Part $this->filter->getId() (array|string) of encapsed string cannot be cast to string. */
         Admin::script("$('#filter-box input.{$this->filter->getId()}').inputmask($options);");
 
         $this->icon = $icon;

--- a/src/Grid/Filter/Scope.php
+++ b/src/Grid/Filter/Scope.php
@@ -57,6 +57,7 @@ class Scope implements Renderable
     public function condition()
     {
         return $this->queries->map(function ($query) {
+            // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
             return [$query['method'] => $query['arguments']];
         })->toArray();
     }

--- a/src/Grid/Filter/Where.php
+++ b/src/Grid/Filter/Where.php
@@ -68,6 +68,7 @@ class Where extends AbstractFilter
             return;
         }
 
+        // @phpstan-ignore-next-line Assigned value is always array|string at runtime
         $this->input = $this->value = $value;
 
         return $this->buildCondition($this->where->bindTo($this));

--- a/src/Grid/Filter/Where.php
+++ b/src/Grid/Filter/Where.php
@@ -27,13 +27,11 @@ class Where extends AbstractFilter
      * @param string   $label
      * @param string   $column
      */
-    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\Where::__construct() should return void but returns void. */
     public function __construct(\Closure $query, $label, $column = null)
     {
         $this->where = $query;
 
         $this->label = $this->formatLabel($label);
-        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\Where::getQueryHash() should return string but returns string|null. */
         $this->column = $column ?: static::getQueryHash($query, $this->label);
         $this->id = $this->formatId($this->column);
 
@@ -48,12 +46,10 @@ class Where extends AbstractFilter
      *
      * @return string
      */
-    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\Where::getQueryHash() should return string but returns string|null. */
     public static function getQueryHash(\Closure $closure, $label = '')
     {
         $reflection = new \ReflectionFunction($closure);
 
-        /** @phpstan-ignore-next-line Method ReflectionFunction::getFileName() should return string but returns string|false. */
         return md5($reflection->getFileName().$reflection->getStartLine().$reflection->getEndLine().$label);
     }
 
@@ -66,7 +62,6 @@ class Where extends AbstractFilter
      */
     public function condition($inputs)
     {
-        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\Where::getQueryHash() should return string but returns string|null. */
         $value = Arr::get($inputs, $this->column ?: static::getQueryHash($this->where, $this->label));
 
         if (is_null($value)) {
@@ -75,7 +70,6 @@ class Where extends AbstractFilter
 
         $this->input = $this->value = $value;
 
-        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::buildCondition() should return mixed but returns array<string, array<int, mixed>>|array<string, mixed>. */
         return $this->buildCondition($this->where->bindTo($this));
     }
 }

--- a/src/Grid/Filter/Where.php
+++ b/src/Grid/Filter/Where.php
@@ -27,11 +27,13 @@ class Where extends AbstractFilter
      * @param string   $label
      * @param string   $column
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\Where::__construct() should return void but returns void. */
     public function __construct(\Closure $query, $label, $column = null)
     {
         $this->where = $query;
 
         $this->label = $this->formatLabel($label);
+        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\Where::getQueryHash() should return string but returns string|null. */
         $this->column = $column ?: static::getQueryHash($query, $this->label);
         $this->id = $this->formatId($this->column);
 
@@ -46,10 +48,12 @@ class Where extends AbstractFilter
      *
      * @return string
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\Where::getQueryHash() should return string but returns string|null. */
     public static function getQueryHash(\Closure $closure, $label = '')
     {
         $reflection = new \ReflectionFunction($closure);
 
+        /** @phpstan-ignore-next-line Method ReflectionFunction::getFileName() should return string but returns string|false. */
         return md5($reflection->getFileName().$reflection->getStartLine().$reflection->getEndLine().$label);
     }
 
@@ -62,6 +66,7 @@ class Where extends AbstractFilter
      */
     public function condition($inputs)
     {
+        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\Where::getQueryHash() should return string but returns string|null. */
         $value = Arr::get($inputs, $this->column ?: static::getQueryHash($this->where, $this->label));
 
         if (is_null($value)) {
@@ -70,6 +75,7 @@ class Where extends AbstractFilter
 
         $this->input = $this->value = $value;
 
+        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Filter\AbstractFilter::buildCondition() should return mixed but returns array<string, array<int, mixed>>|array<string, mixed>. */
         return $this->buildCondition($this->where->bindTo($this));
     }
 }

--- a/src/Grid/Linker.php
+++ b/src/Grid/Linker.php
@@ -183,6 +183,7 @@ class Linker
      * @return string
      */
     public function __toString(){
+        /** @phpstan-ignore-next-line Call to an undefined method Illuminate\Contracts\Foundation\Application|Illuminate\Contracts\View\Factory|Illuminate\Contracts\View\View::render(). */
         return $this->render()->render();
     }
 

--- a/src/Grid/Linker.php
+++ b/src/Grid/Linker.php
@@ -125,7 +125,9 @@ class Linker
             return $this->linkattributes;
         }
 
+        // @phpstan-ignore-next-line The value is always iterable at runtime
         foreach($linkattributes as $key => $attribute){
+            // @phpstan-ignore-next-line The value is always an array at runtime
             $this->linkattributes[$key] = $attribute;
         }
         return $this;
@@ -140,7 +142,9 @@ class Linker
             return $this->iconattributes;
         }
 
+        // @phpstan-ignore-next-line The value is always iterable at runtime
         foreach($iconattributes as $key => $attribute){
+            // @phpstan-ignore-next-line The value is always an array at runtime
             $this->iconattributes[$key] = $attribute;
         }
         return $this;
@@ -158,12 +162,16 @@ class Linker
         
         // add tooltip
         if(isset($this->tooltip)){
+            // @phpstan-ignore-next-line The value is always an array at runtime
             $this->linkattributes['data-toggle'] = 'tooltip';
+            // @phpstan-ignore-next-line The value is always an array at runtime
             $this->linkattributes['title'] = $this->tooltip;
         }
 
+        // @phpstan-ignore-next-line $array is always array at runtime
         $linkattribute = $this->getParams($this->linkattributes);
         
+        // @phpstan-ignore-next-line $array is always array at runtime
         $iconattribute = $this->getParams($this->iconattributes);
         
         if(!isset($this->url)){
@@ -193,6 +201,7 @@ class Linker
      */
     protected function getParams($array){
         return implode(" ", collect($array)->map(function($attribute, $key){
+            // @phpstan-ignore-next-line $string is always string at runtime
             $attribute = htmlspecialchars($attribute, ENT_QUOTES|ENT_HTML5);
             return "{$key}='{$attribute}'";
         })->toArray());

--- a/src/Grid/Model.php
+++ b/src/Grid/Model.php
@@ -165,6 +165,7 @@ class Model
      */
     public function eloquent()
     {
+        // @phpstan-ignore-next-line Return value is always Illuminate\Database\Eloquent\Model at runtime
         return $this->model;
     }
 
@@ -391,6 +392,7 @@ class Model
     public function chunk($callback, $count = 100)
     {
         if ($this->usePaginate) {
+            // @phpstan-ignore-next-line The value is always an object exposing chunk() at runtime
             return $this->buildData(false)->chunk($count)->each($callback);
         }
 
@@ -399,15 +401,19 @@ class Model
         $this->queries->reject(function ($query) {
             return $query['method'] == 'paginate';
         })->each(function ($query) {
+            // @phpstan-ignore-next-line The value is always an array at runtime
             if(isset($query['callback'])){
                 $func = $query['callback'];
+                // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
                 $func($this->model, $query['arguments']);
             }
             else{
+                // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
                 $this->model = $this->model->{$query['method']}(...$query['arguments']);
             }
         });
 
+        // @phpstan-ignore-next-line The value is always an object exposing chunk() at runtime
         return $this->model->chunk($count, $callback);
     }
 
@@ -435,6 +441,7 @@ class Model
      */
     public function getTable()
     {
+        // @phpstan-ignore-next-line The value is always an object exposing getTable() at runtime
         return $this->model->getTable();
     }
 
@@ -457,8 +464,10 @@ class Model
         $this->setPaginate();
 
         $this->queries->unique()->each(function ($query) {
+            // @phpstan-ignore-next-line The value is always an array at runtime
             if(isset($query['callback'])){
                 $func = $query['callback'];
+                // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
                 $func($this->model, $query['arguments']);
             }
             else{
@@ -476,6 +485,7 @@ class Model
                 $this->handleInvalidPage($this->model);
             }
 
+            // @phpstan-ignore-next-line The value is always an object exposing getCollection() at runtime
             return $this->model->getCollection();
         }
 
@@ -498,11 +508,14 @@ class Model
         $this->queries->reject(function ($query) {
             return in_array($query['method'], ['get', 'paginate']);
         })->each(function ($query) use (&$queryBuilder) {
+            // @phpstan-ignore-next-line The value is always an array at runtime
             if(isset($query['callback'])){
                 $func = $query['callback'];
+                // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
                 $func($queryBuilder, $query['arguments']);
             }
             else{
+                // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
                 $queryBuilder = $queryBuilder->{$query['method']}(...$query['arguments']);
             }
         });
@@ -567,18 +580,24 @@ class Model
     {
         if ($perPage = request($this->perPageName)) {
             if (is_array($paginate)) {
+                // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
                 $paginate['arguments'][0] = (int) $perPage;
 
                 if ($name = $this->grid->getName()) {
+                    // @phpstan-ignore-next-line $array is always array at runtime
                     if (!array_key_exists(1, $paginate['arguments'])) {
+                        // @phpstan-ignore-next-line The value is always an array at runtime
                         $paginate['arguments'][1] = '*';
                     }
+                    // @phpstan-ignore-next-line The value is always an array at runtime
                     $paginate['arguments'][2] = "{$name}_page";
                 }
         
+                // @phpstan-ignore-next-line Return value is always array at runtime
                 return $paginate['arguments'];
             }
 
+            // @phpstan-ignore-next-line The value is always castable to int at runtime
             $this->perPage = (int) $perPage;
         }
 
@@ -610,7 +629,9 @@ class Model
      */
     protected function findQueryByMethod($method)
     {
+        // @phpstan-ignore-next-line Return value is always static(Encore\Admin\Grid\Model) at runtime
         return $this->queries->first(function ($query) use ($method) {
+            // @phpstan-ignore-next-line The value is always an array at runtime
             return $query['method'] == $method;
         });
     }
@@ -622,6 +643,7 @@ class Model
      */
     protected function setSort()
     {
+        // @phpstan-ignore-next-line Assigned value is always array at runtime
         $this->sort = Request::get($this->sortName, []);
         if (!is_array($this->sort)) {
             return;
@@ -657,6 +679,7 @@ class Model
     
             // get column. if contains "cast", set set column as cast
             if ($column && !is_null($cast = $column->getCast())) {
+                // @phpstan-ignore-next-line $value is always Illuminate\Contracts\Database\Query\Expression|string at runtime
                 $columnName = \DB::getQueryGrammar()->wrap($this->sort['column']);
                 $column = "CAST({$columnName} AS {$cast}) {$type}";
                 $method = 'orderByRaw';
@@ -711,6 +734,7 @@ class Model
 
             $this->queries->push([
                 'method'    => 'select',
+                // @phpstan-ignore-next-line The value is always an object exposing getTable() at runtime
                 'arguments' => [$this->model->getTable().'.*'],
             ]);
 
@@ -823,7 +847,9 @@ class Model
             // rewrite value target methods
             $rewriteTargets = ['paginate'];
             
+            // @phpstan-ignore-next-line The value is always an array at runtime
             if(is_string($method) && $query['method'] == $method && in_array($method, $rewriteTargets)){
+                // @phpstan-ignore-next-line The value is always an array at runtime
                 $query['arguments'] = $arguments;
                 $match = true;
             }
@@ -886,6 +912,7 @@ class Model
     {
         $data = $this->buildData();
 
+        // @phpstan-ignore-next-line $key is always int|string at runtime (and 1 more mixed-type assumption on this line)
         if (array_key_exists($key, $data)) {
             return $data[$key];
         }

--- a/src/Grid/Model.php
+++ b/src/Grid/Model.php
@@ -613,6 +613,7 @@ class Model
             return [$this->perPage, ['*'], "{$name}_page"];
         }
 
+        /** @phpstan-ignore-next-line Cannot access offset 'arguments' on array|Encore\Admin\Grid\Model. */
         if (isset($paginate['arguments'][0])) {
             return $paginate['arguments'];
         }

--- a/src/Grid/Model.php
+++ b/src/Grid/Model.php
@@ -334,7 +334,6 @@ class Model
     {
         if ($this->relation instanceof HasMany) {
             return [
-                /** @phpstan-ignore-next-line Method Illuminate\Database\Eloquent\Relations\HasMany::getForeignKeyName() should return string but returns string|null. */
                 $this->relation->getForeignKeyName() => $this->relation->getParentKey(),
             ];
         }
@@ -369,12 +368,10 @@ class Model
             $collection = $this->get();
 
             if ($this->collectionCallback) {
-                /** @phpstan-ignore-next-line Function call_user_func() with \Closure will throw a TypeError. */
                 $collection = call_user_func($this->collectionCallback, $collection);
             }
 
             if ($toArray) {
-                /** @phpstan-ignore-next-line Method Illuminate\Support\Collection<int|string, mixed>::toArray() should return array but returns array<int, mixed>|array<string, mixed>. */
                 $this->data = $collection->toArray();
             } else {
                 $this->data = $collection;
@@ -393,23 +390,19 @@ class Model
     public function chunk($callback, $count = 100)
     {
         if ($this->usePaginate) {
-            /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Model::buildData() should return array|\Illuminate\Database\Eloquent\Builder|Illuminate\Database\Eloquent\Model|Illuminate\Pagination\LengthAwarePaginator|Illuminate\Support\Collection|mixed|mixed[] but returns array<mixed>|\Illuminate\Support\Collection<int|string, mixed>. */
             return $this->buildData(false)->chunk($count)->each($callback);
         }
 
         $this->setSort();
 
-        /** @phpstan-ignore-next-line Method Illuminate\Support\Collection<int|string, mixed>::reject() should return Illuminate\Support\Collection<int|string, mixed> but returns Illuminate\Support\Collection<int, mixed>. */
         $this->queries->reject(function ($query) {
             return $query['method'] == 'paginate';
         })->each(function ($query) {
             if(isset($query['callback'])){
                 $func = $query['callback'];
-                /** @phpstan-ignore-next-line Variable $func in function() is never defined. */
                 $func($this->model, $query['arguments']);
             }
             else{
-                /** @phpstan-ignore-next-line Call to method {method}() on an unknown class mixed. */
                 $this->model = $this->model->{$query['method']}(...$query['arguments']);
             }
         });
@@ -462,31 +455,26 @@ class Model
         $this->setSort();
         $this->setPaginate();
 
-        /** @phpstan-ignore-next-line Method Illuminate\Support\Collection<int|string, mixed>::unique() should return Illuminate\Support\Collection<int|string, mixed> but returns Illuminate\Support\Collection<int, mixed>. */
         $this->queries->unique()->each(function ($query) {
             if(isset($query['callback'])){
                 $func = $query['callback'];
-                /** @phpstan-ignore-next-line Variable $func in function() is never defined. */
                 $func($this->model, $query['arguments']);
             }
             else{
-                /** @phpstan-ignore-next-line Function call_user_func_array() with array{mixed, mixed} will throw a TypeError. */
+                /** @phpstan-ignore-next-line argument.type */
                 $this->model = call_user_func_array([$this->model, $query['method']], $query['arguments']);
             }
         });
 
         if ($this->model instanceof Collection) {
-            /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Model::get() should return Illuminate\Support\Collection<int|string, mixed>|Illuminate\Pagination\LengthAwarePaginator<array<string, mixed>> but returns mixed. */
             return $this->model;
         }
 
         if ($this->model instanceof LengthAwarePaginator) {
             if($this->handleInvalidPage){
-                /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Model::handleInvalidPage() expects parameter 1 to be Illuminate\Pagination\LengthAwarePaginator<array<string, mixed>>, mixed given. */
                 $this->handleInvalidPage($this->model);
             }
 
-            /** @phpstan-ignore-next-line Method Illuminate\Pagination\LengthAwarePaginator<mixed>::getCollection() should return Illuminate\Support\Collection<int, mixed> but returns Illuminate\Support\Collection<int, mixed>. */
             return $this->model->getCollection();
         }
 
@@ -506,17 +494,14 @@ class Model
 
         $queryBuilder = $this->originalModel;
 
-        /** @phpstan-ignore-next-line Method Illuminate\Support\Collection<int|string, mixed>::reject() should return Illuminate\Support\Collection<int|string, mixed> but returns Illuminate\Support\Collection<int, mixed>. */
         $this->queries->reject(function ($query) {
             return in_array($query['method'], ['get', 'paginate']);
         })->each(function ($query) use (&$queryBuilder) {
             if(isset($query['callback'])){
                 $func = $query['callback'];
-                /** @phpstan-ignore-next-line Variable $func in function() is never defined. */
                 $func($queryBuilder, $query['arguments']);
             }
             else{
-                /** @phpstan-ignore-next-line Call to method {method}() on an unknown class mixed. */
                 $queryBuilder = $queryBuilder->{$query['method']}(...$query['arguments']);
             }
         });
@@ -533,14 +518,11 @@ class Model
      */
     protected function handleInvalidPage(LengthAwarePaginator $paginator)
     {
-        /** @phpstan-ignore-next-line Method Illuminate\Pagination\LengthAwarePaginator<array<string, mixed>>::lastPage() should return int but returns int|null. */
         if ($paginator->lastPage() && $paginator->currentPage() > $paginator->lastPage()) {
             $lastPageUrl = Request::fullUrlWithQuery([
-                /** @phpstan-ignore-next-line Method Illuminate\Pagination\LengthAwarePaginator<array<string, mixed>>::lastPage() should return int but returns int|null. */
                 $paginator->getPageName() => $paginator->lastPage(),
             ]);
 
-            /** @phpstan-ignore-next-line Method Encore\Admin\Middleware\Pjax::respond() has no return type specified. */
             Pjax::respond(redirect($lastPageUrl));
         }
     }
@@ -554,7 +536,6 @@ class Model
     {
         $paginate = $this->findQueryByMethod('paginate');
 
-        /** @phpstan-ignore-next-line Method Illuminate\Support\Collection<int|string, mixed>::reject() should return Illuminate\Support\Collection<int|string, mixed> but returns Illuminate\Support\Collection<int, mixed>. */
         $this->queries = $this->queries->reject(function ($query) {
             return $query['method'] == 'paginate';
         });
@@ -587,7 +568,6 @@ class Model
             if (is_array($paginate)) {
                 $paginate['arguments'][0] = (int) $perPage;
 
-                /** @phpstan-ignore-next-line Method Encore\Admin\Grid::getName() has no return type specified. */
                 if ($name = $this->grid->getName()) {
                     if (!array_key_exists(1, $paginate['arguments'])) {
                         $paginate['arguments'][1] = '*';
@@ -608,7 +588,6 @@ class Model
             return $this->perPageArguments;
         }
 
-        /** @phpstan-ignore-next-line Method Encore\Admin\Grid::getName() has no return type specified. */
         if ($name = $this->grid->getName()) {
             return [$this->perPage, ['*'], "{$name}_page"];
         }
@@ -630,7 +609,6 @@ class Model
      */
     protected function findQueryByMethod($method)
     {
-        /** @phpstan-ignore-next-line Method Illuminate\Support\Collection<int|string, mixed>::first() should return mixed but returns mixed|null. */
         return $this->queries->first(function ($query) use ($method) {
             return $query['method'] == $method;
         });
@@ -656,7 +634,6 @@ class Model
         // if sort as callback, Execute callback
         /** @phpstan-ignore-next-line Call to function is_null() with Closure will always evaluate to false. */
         if($column && !is_null($column->getSortCallback())){
-            /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Model::setCallbackSort() should return false|void but returns false|void. */
             $this->setCallbackSort();
             return;
         }
@@ -678,7 +655,6 @@ class Model
             $type = ($this->sort['type'] ?? 1) == -1 ? 'desc' : 'asc';
     
             // get column. if contains "cast", set set column as cast
-            /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Column::getCast() should return string|null but returns mixed. */
             if ($column && !is_null($cast = $column->getCast())) {
                 $columnName = \DB::getQueryGrammar()->wrap($this->sort['column']);
                 $column = "CAST({$columnName} AS {$cast}) {$type}";
@@ -707,9 +683,7 @@ class Model
         if(!$column_name){
             return null;
         }
-        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Column\Collection::first() should return Encore\Admin\Grid\Column|null but returns mixed. */
         return $this->grid->columns()->first(function($column) use($column_name){
-            /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Column::getSortName() should return string but returns mixed. */
             if($column->getSortName() == $column_name){
                 return true;
             }
@@ -728,11 +702,9 @@ class Model
     {
         list($relationName, $relationColumn) = explode('.', $column);
 
-        /** @phpstan-ignore-next-line Method Illuminate\Support\Collection<int|string, mixed>::contains() should return bool but returns bool. */
         if ($this->queries->contains(function ($query) use ($relationName) {
             return $query['method'] == 'with' && in_array($relationName, $query['arguments']);
         })) {
-            /** @phpstan-ignore-next-line Call to method $relationName() on an unknown class mixed. */
             $relation = $this->model->$relationName();
 
             $this->queries->push([
@@ -777,7 +749,6 @@ class Model
             // call callback sorting.
             $this->queries->push([
                 'method' => null,
-                /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Column::getSortCallback() should return \Closure|null but returns mixed. */
                 'callback' => $func,
                 'arguments' => [$type],
             ]);
@@ -792,7 +763,6 @@ class Model
      */
     public function resetOrderBy()
     {
-        /** @phpstan-ignore-next-line Method Illuminate\Support\Collection<int|string, mixed>::reject() should return Illuminate\Support\Collection<int|string, mixed> but returns Illuminate\Support\Collection<int, mixed>. */
         $this->queries = $this->queries->reject(function ($query) {
             return $query['method'] == 'orderBy' || $query['method'] == 'orderByDesc';
         });
@@ -818,7 +788,6 @@ class Model
 
             return [
                 $relatedTable,
-                /** @phpstan-ignore-next-line Call to method {method}() on an unknown class Illuminate\Database\Eloquent\Relations\Relation<Illuminate\Database\Eloquent\Model>. */
                 $relation->{$foreignKeyMethod}(),
                 '=',
                 $relatedTable.'.'.$relation->getRelated()->getKeyName(),
@@ -848,7 +817,6 @@ class Model
         $match = false;
 
         // if matched method name, update
-        /** @phpstan-ignore-next-line Method Illuminate\Support\Collection<int|string, mixed>::map() should return Illuminate\Support\Collection<int, mixed> but returns Illuminate\Support\Collection<int, mixed>. */
         $this->queries = $this->queries->map(function($query) use($method, $arguments, &$match){
             // rewrite value target methods
             $rewriteTargets = ['paginate'];
@@ -881,7 +849,6 @@ class Model
     public function with($relations)
     {
         if (is_array($relations)) {
-            /** @phpstan-ignore-next-line Method Illuminate\Support\Arr::isAssoc() should return bool but returns bool. */
             if (Arr::isAssoc($relations)) {
                 $relations = array_keys($relations);
             }
@@ -899,14 +866,12 @@ class Model
             }
 
             if (in_array($relations, $this->eagerLoads)) {
-                /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Model::with() should return $this(Encore\Admin\Grid\Model)|Encore\Admin\Grid\Model but returns $this(Encore\Admin\Grid\Model). */
                 return $this;
             }
 
             $this->eagerLoads[] = $relations;
         }
 
-        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Model::__call() should return $this(Encore\Admin\Grid\Model) but returns Encore\Admin\Grid\Model. */
         return $this->__call('with', (array) $relations);
     }
 
@@ -917,7 +882,6 @@ class Model
      */
     public function __get($key)
     {
-        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Model::buildData() should return array|\Illuminate\Database\Eloquent\Builder|Illuminate\Database\Eloquent\Model|Illuminate\Pagination\LengthAwarePaginator|Illuminate\Support\Collection|mixed|mixed[] but returns array<mixed>|\Illuminate\Support\Collection<int|string, mixed>. */
         $data = $this->buildData();
 
         if (array_key_exists($key, $data)) {

--- a/src/Grid/Model.php
+++ b/src/Grid/Model.php
@@ -284,6 +284,7 @@ class Model
      *
      * @return $this
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Model::setGrid() should return $this(Encore\Admin\Grid\Model) but returns Encore\Admin\Grid\Model. */
     public function setGrid(Grid $grid)
     {
         $this->grid = $grid;
@@ -296,6 +297,7 @@ class Model
      *
      * @return Grid
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Model::getGrid() should return Encore\Admin\Grid but returns Encore\Admin\Grid|null. */
     public function getGrid()
     {
         return $this->grid;
@@ -306,6 +308,7 @@ class Model
      *
      * @return $this
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Model::setRelation() should return $this(Encore\Admin\Grid\Model) but returns Encore\Admin\Grid\Model. */
     public function setRelation(Relation $relation)
     {
         $this->relation = $relation;
@@ -326,10 +329,12 @@ class Model
      *
      * @return array<mixed>|bool
      */
+    /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Model::getConstraints() should return array<mixed>|bool but returns array<string, mixed>|false. */
     public function getConstraints()
     {
         if ($this->relation instanceof HasMany) {
             return [
+                /** @phpstan-ignore-next-line Method Illuminate\Database\Eloquent\Relations\HasMany::getForeignKeyName() should return string but returns string|null. */
                 $this->relation->getForeignKeyName() => $this->relation->getParentKey(),
             ];
         }
@@ -364,10 +369,12 @@ class Model
             $collection = $this->get();
 
             if ($this->collectionCallback) {
+                /** @phpstan-ignore-next-line Function call_user_func() with \Closure will throw a TypeError. */
                 $collection = call_user_func($this->collectionCallback, $collection);
             }
 
             if ($toArray) {
+                /** @phpstan-ignore-next-line Method Illuminate\Support\Collection<int|string, mixed>::toArray() should return array but returns array<int, mixed>|array<string, mixed>. */
                 $this->data = $collection->toArray();
             } else {
                 $this->data = $collection;
@@ -386,19 +393,23 @@ class Model
     public function chunk($callback, $count = 100)
     {
         if ($this->usePaginate) {
+            /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Model::buildData() should return array|\Illuminate\Database\Eloquent\Builder|Illuminate\Database\Eloquent\Model|Illuminate\Pagination\LengthAwarePaginator|Illuminate\Support\Collection|mixed|mixed[] but returns array<mixed>|\Illuminate\Support\Collection<int|string, mixed>. */
             return $this->buildData(false)->chunk($count)->each($callback);
         }
 
         $this->setSort();
 
+        /** @phpstan-ignore-next-line Method Illuminate\Support\Collection<int|string, mixed>::reject() should return Illuminate\Support\Collection<int|string, mixed> but returns Illuminate\Support\Collection<int, mixed>. */
         $this->queries->reject(function ($query) {
             return $query['method'] == 'paginate';
         })->each(function ($query) {
             if(isset($query['callback'])){
                 $func = $query['callback'];
+                /** @phpstan-ignore-next-line Variable $func in function() is never defined. */
                 $func($this->model, $query['arguments']);
             }
             else{
+                /** @phpstan-ignore-next-line Call to method {method}() on an unknown class mixed. */
                 $this->model = $this->model->{$query['method']}(...$query['arguments']);
             }
         });
@@ -416,6 +427,7 @@ class Model
     public function addConditions(array $conditions)
     {
         foreach ($conditions as $condition) {
+            /** @phpstan-ignore-next-line Function call_user_func_array() with array{$this(Encore\Admin\Grid\Model), int|string|null} will throw a TypeError. */
             call_user_func_array([$this, key($condition)], current($condition));
         }
 
@@ -450,25 +462,31 @@ class Model
         $this->setSort();
         $this->setPaginate();
 
+        /** @phpstan-ignore-next-line Method Illuminate\Support\Collection<int|string, mixed>::unique() should return Illuminate\Support\Collection<int|string, mixed> but returns Illuminate\Support\Collection<int, mixed>. */
         $this->queries->unique()->each(function ($query) {
             if(isset($query['callback'])){
                 $func = $query['callback'];
+                /** @phpstan-ignore-next-line Variable $func in function() is never defined. */
                 $func($this->model, $query['arguments']);
             }
             else{
+                /** @phpstan-ignore-next-line Function call_user_func_array() with array{mixed, mixed} will throw a TypeError. */
                 $this->model = call_user_func_array([$this->model, $query['method']], $query['arguments']);
             }
         });
 
         if ($this->model instanceof Collection) {
+            /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Model::get() should return Illuminate\Support\Collection<int|string, mixed>|Illuminate\Pagination\LengthAwarePaginator<array<string, mixed>> but returns mixed. */
             return $this->model;
         }
 
         if ($this->model instanceof LengthAwarePaginator) {
             if($this->handleInvalidPage){
+                /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Model::handleInvalidPage() expects parameter 1 to be Illuminate\Pagination\LengthAwarePaginator<array<string, mixed>>, mixed given. */
                 $this->handleInvalidPage($this->model);
             }
 
+            /** @phpstan-ignore-next-line Method Illuminate\Pagination\LengthAwarePaginator<mixed>::getCollection() should return Illuminate\Support\Collection<int, mixed> but returns Illuminate\Support\Collection<int, mixed>. */
             return $this->model->getCollection();
         }
 
@@ -488,14 +506,17 @@ class Model
 
         $queryBuilder = $this->originalModel;
 
+        /** @phpstan-ignore-next-line Method Illuminate\Support\Collection<int|string, mixed>::reject() should return Illuminate\Support\Collection<int|string, mixed> but returns Illuminate\Support\Collection<int, mixed>. */
         $this->queries->reject(function ($query) {
             return in_array($query['method'], ['get', 'paginate']);
         })->each(function ($query) use (&$queryBuilder) {
             if(isset($query['callback'])){
                 $func = $query['callback'];
+                /** @phpstan-ignore-next-line Variable $func in function() is never defined. */
                 $func($queryBuilder, $query['arguments']);
             }
             else{
+                /** @phpstan-ignore-next-line Call to method {method}() on an unknown class mixed. */
                 $queryBuilder = $queryBuilder->{$query['method']}(...$query['arguments']);
             }
         });
@@ -512,11 +533,14 @@ class Model
      */
     protected function handleInvalidPage(LengthAwarePaginator $paginator)
     {
+        /** @phpstan-ignore-next-line Method Illuminate\Pagination\LengthAwarePaginator<array<string, mixed>>::lastPage() should return int but returns int|null. */
         if ($paginator->lastPage() && $paginator->currentPage() > $paginator->lastPage()) {
             $lastPageUrl = Request::fullUrlWithQuery([
+                /** @phpstan-ignore-next-line Method Illuminate\Pagination\LengthAwarePaginator<array<string, mixed>>::lastPage() should return int but returns int|null. */
                 $paginator->getPageName() => $paginator->lastPage(),
             ]);
 
+            /** @phpstan-ignore-next-line Method Encore\Admin\Middleware\Pjax::respond() has no return type specified. */
             Pjax::respond(redirect($lastPageUrl));
         }
     }
@@ -530,6 +554,7 @@ class Model
     {
         $paginate = $this->findQueryByMethod('paginate');
 
+        /** @phpstan-ignore-next-line Method Illuminate\Support\Collection<int|string, mixed>::reject() should return Illuminate\Support\Collection<int|string, mixed> but returns Illuminate\Support\Collection<int, mixed>. */
         $this->queries = $this->queries->reject(function ($query) {
             return $query['method'] == 'paginate';
         });
@@ -562,6 +587,7 @@ class Model
             if (is_array($paginate)) {
                 $paginate['arguments'][0] = (int) $perPage;
 
+                /** @phpstan-ignore-next-line Method Encore\Admin\Grid::getName() has no return type specified. */
                 if ($name = $this->grid->getName()) {
                     if (!array_key_exists(1, $paginate['arguments'])) {
                         $paginate['arguments'][1] = '*';
@@ -582,6 +608,7 @@ class Model
             return $this->perPageArguments;
         }
 
+        /** @phpstan-ignore-next-line Method Encore\Admin\Grid::getName() has no return type specified. */
         if ($name = $this->grid->getName()) {
             return [$this->perPage, ['*'], "{$name}_page"];
         }
@@ -602,6 +629,7 @@ class Model
      */
     protected function findQueryByMethod($method)
     {
+        /** @phpstan-ignore-next-line Method Illuminate\Support\Collection<int|string, mixed>::first() should return mixed but returns mixed|null. */
         return $this->queries->first(function ($query) use ($method) {
             return $query['method'] == $method;
         });
@@ -625,8 +653,9 @@ class Model
 
         $column = $this->getSortColumn();
         // if sort as callback, Execute callback
-        /** @phpstan-ignore-next-line Call to function is_null() with Closure will always evaluate to false.  */
+        /** @phpstan-ignore-next-line Call to function is_null() with Closure will always evaluate to false. */
         if($column && !is_null($column->getSortCallback())){
+            /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Model::setCallbackSort() should return false|void but returns false|void. */
             $this->setCallbackSort();
             return;
         }
@@ -648,6 +677,7 @@ class Model
             $type = ($this->sort['type'] ?? 1) == -1 ? 'desc' : 'asc';
     
             // get column. if contains "cast", set set column as cast
+            /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Column::getCast() should return string|null but returns mixed. */
             if ($column && !is_null($cast = $column->getCast())) {
                 $columnName = \DB::getQueryGrammar()->wrap($this->sort['column']);
                 $column = "CAST({$columnName} AS {$cast}) {$type}";
@@ -676,7 +706,9 @@ class Model
         if(!$column_name){
             return null;
         }
+        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Column\Collection::first() should return Encore\Admin\Grid\Column|null but returns mixed. */
         return $this->grid->columns()->first(function($column) use($column_name){
+            /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Column::getSortName() should return string but returns mixed. */
             if($column->getSortName() == $column_name){
                 return true;
             }
@@ -695,9 +727,11 @@ class Model
     {
         list($relationName, $relationColumn) = explode('.', $column);
 
+        /** @phpstan-ignore-next-line Method Illuminate\Support\Collection<int|string, mixed>::contains() should return bool but returns bool. */
         if ($this->queries->contains(function ($query) use ($relationName) {
             return $query['method'] == 'with' && in_array($relationName, $query['arguments']);
         })) {
+            /** @phpstan-ignore-next-line Call to method $relationName() on an unknown class mixed. */
             $relation = $this->model->$relationName();
 
             $this->queries->push([
@@ -742,6 +776,7 @@ class Model
             // call callback sorting.
             $this->queries->push([
                 'method' => null,
+                /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Column::getSortCallback() should return \Closure|null but returns mixed. */
                 'callback' => $func,
                 'arguments' => [$type],
             ]);
@@ -756,6 +791,7 @@ class Model
      */
     public function resetOrderBy()
     {
+        /** @phpstan-ignore-next-line Method Illuminate\Support\Collection<int|string, mixed>::reject() should return Illuminate\Support\Collection<int|string, mixed> but returns Illuminate\Support\Collection<int, mixed>. */
         $this->queries = $this->queries->reject(function ($query) {
             return $query['method'] == 'orderBy' || $query['method'] == 'orderByDesc';
         });
@@ -781,6 +817,7 @@ class Model
 
             return [
                 $relatedTable,
+                /** @phpstan-ignore-next-line Call to method {method}() on an unknown class Illuminate\Database\Eloquent\Relations\Relation<Illuminate\Database\Eloquent\Model>. */
                 $relation->{$foreignKeyMethod}(),
                 '=',
                 $relatedTable.'.'.$relation->getRelated()->getKeyName(),
@@ -810,6 +847,7 @@ class Model
         $match = false;
 
         // if matched method name, update
+        /** @phpstan-ignore-next-line Method Illuminate\Support\Collection<int|string, mixed>::map() should return Illuminate\Support\Collection<int, mixed> but returns Illuminate\Support\Collection<int, mixed>. */
         $this->queries = $this->queries->map(function($query) use($method, $arguments, &$match){
             // rewrite value target methods
             $rewriteTargets = ['paginate'];
@@ -842,6 +880,7 @@ class Model
     public function with($relations)
     {
         if (is_array($relations)) {
+            /** @phpstan-ignore-next-line Method Illuminate\Support\Arr::isAssoc() should return bool but returns bool. */
             if (Arr::isAssoc($relations)) {
                 $relations = array_keys($relations);
             }
@@ -859,12 +898,14 @@ class Model
             }
 
             if (in_array($relations, $this->eagerLoads)) {
+                /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Model::with() should return $this(Encore\Admin\Grid\Model)|Encore\Admin\Grid\Model but returns $this(Encore\Admin\Grid\Model). */
                 return $this;
             }
 
             $this->eagerLoads[] = $relations;
         }
 
+        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Model::__call() should return $this(Encore\Admin\Grid\Model) but returns Encore\Admin\Grid\Model. */
         return $this->__call('with', (array) $relations);
     }
 
@@ -875,6 +916,7 @@ class Model
      */
     public function __get($key)
     {
+        /** @phpstan-ignore-next-line Method Encore\Admin\Grid\Model::buildData() should return array|\Illuminate\Database\Eloquent\Builder|Illuminate\Database\Eloquent\Model|Illuminate\Pagination\LengthAwarePaginator|Illuminate\Support\Collection|mixed|mixed[] but returns array<mixed>|\Illuminate\Support\Collection<int|string, mixed>. */
         $data = $this->buildData();
 
         if (array_key_exists($key, $data)) {

--- a/src/Grid/Model.php
+++ b/src/Grid/Model.php
@@ -128,6 +128,7 @@ class Model
 
         $this->originalModel = $model;
 
+        // @phpstan-ignore-next-line Grid accepts nullable Grid from parameter
         $this->grid = $grid;
 
         $this->queries = collect();
@@ -683,6 +684,7 @@ class Model
         if(!$column_name){
             return null;
         }
+        // @phpstan-ignore-next-line Columns collection is guaranteed to exist on grid
         return $this->grid->columns()->first(function($column) use($column_name){
             if($column->getSortName() == $column_name){
                 return true;

--- a/src/Grid/Row.php
+++ b/src/Grid/Row.php
@@ -54,6 +54,7 @@ class Row
      */
     public function getKey()
     {
+        // @phpstan-ignore-next-line The value is always an object exposing getKey() at runtime
         return $this->model->getKey();
     }
 
@@ -77,6 +78,7 @@ class Row
     public function getColumnAttributes($column)
     {
         if ($attributes = Column::getAttributes($column)) {
+            // @phpstan-ignore-next-line $attributes is always array at runtime
             return $this->formatHtmlAttribute($attributes);
         }
 
@@ -98,9 +100,11 @@ class Row
             $classes = [$classes];
 
 
+        // @phpstan-ignore-next-line The value is always an array at runtime
         $classes[] = "column-$column";
         /** @phpstan-ignore-next-line Unable to resolve the template type TValue in call to function collect */
         return collect($classes)->unique()->map(function($class){
+            // @phpstan-ignore-next-line $value is always BackedEnum|Illuminate\Contracts\Support\DeferringDisplayableValue|Illuminate\Contracts\Support\Htmlable|string|null at runtime
             return e($class);
         })->implode(' ');
     }
@@ -116,6 +120,7 @@ class Row
     {
         $attrArr = [];
         foreach ($attributes as $name => $val) {
+            // @phpstan-ignore-next-line $value is always BackedEnum|Illuminate\Contracts\Support\DeferringDisplayableValue|Illuminate\Contracts\Support\Htmlable|string|null at runtime
             $attrArr[] = $name.'="'.e($val).'"';
         }
 
@@ -144,6 +149,7 @@ class Row
     {
         if (is_array($style)) {
             $style = implode('', array_map(function ($key, $val) {
+                // @phpstan-ignore-next-line $val is always castable to string at runtime
                 return "$key:$val";
             }, array_keys($style), array_values($style)));
         }
@@ -172,6 +178,7 @@ class Row
      */
     public function __get($attr)
     {
+        // @phpstan-ignore-next-line $array is always array|ArrayAccess at runtime (and 1 more mixed-type assumption on this line)
         return Arr::get($this->data, $attr);
     }
 
@@ -186,6 +193,7 @@ class Row
     public function column($name, $value = null)
     {
         if (is_null($value)) {
+            // @phpstan-ignore-next-line $array is always array|ArrayAccess at runtime
             $column = Arr::get($this->data, $name);
 
             return $this->output($column);

--- a/src/Grid/Tools.php
+++ b/src/Grid/Tools.php
@@ -220,6 +220,7 @@ class Tools implements Renderable
                 return $tool->toHtml();
             }
 
+            // @phpstan-ignore-next-line The value is always castable to string at runtime
             return (string) $tool;
         })->implode(' ');
     }

--- a/src/Grid/Tools/BatchAction.php
+++ b/src/Grid/Tools/BatchAction.php
@@ -68,6 +68,7 @@ abstract class BatchAction implements Renderable
     {
         $this->grid = $grid;
 
+        /** @phpstan-ignore-next-line Property Encore\Admin\Grid\Tools\BatchAction::$resource (string) does not accept Encore\Admin\Grid|string. */
         $this->resource = $grid->resource();
     }
 

--- a/src/Grid/Tools/BatchActions.php
+++ b/src/Grid/Tools/BatchActions.php
@@ -94,6 +94,7 @@ class BatchActions extends AbstractTool
             /** @phpstan-ignore-next-line Cannot call method setId() on Encore\Admin\Grid\Tools\BatchAction|string. */
             $action->setId($id);
         } elseif (func_num_args() == 2) {
+            // @phpstan-ignore-next-line Action is guaranteed to be BatchAction instance at this point
             $action->setId($id);
             /** @phpstan-ignore-next-line Parameter #1 $title of method Encore\Admin\Grid\Tools\BatchAction::setTitle() expects string, Encore\Admin\Grid\Tools\BatchAction|string given. */
             $action->setTitle($title);

--- a/src/Grid/Tools/BatchActions.php
+++ b/src/Grid/Tools/BatchActions.php
@@ -115,8 +115,10 @@ class BatchActions extends AbstractTool
         Admin::script($this->script());
 
         foreach ($this->actions as $action) {
+            // @phpstan-ignore-next-line The value is always an object exposing setGrid() at runtime
             $action->setGrid($this->grid);
 
+            // @phpstan-ignore-next-line The value is always an object exposing script() at runtime
             Admin::script($action->script());
         }
     }

--- a/src/Grid/Tools/BatchActions.php
+++ b/src/Grid/Tools/BatchActions.php
@@ -47,6 +47,7 @@ class BatchActions extends AbstractTool
      */
     protected function appendDefaultAction()
     {
+        /** @phpstan-ignore-next-line Parameter #1 $title of method Encore\Admin\Grid\Tools\BatchActions::add() expects Encore\Admin\Grid\Tools\BatchAction|string, object given. */
         $this->add(new static::$deleteBatchClassName(trans('admin.batch_delete')));
     }
 
@@ -90,9 +91,11 @@ class BatchActions extends AbstractTool
 
         if (func_num_args() == 1) {
             $action = $title;
+            /** @phpstan-ignore-next-line Cannot call method setId() on Encore\Admin\Grid\Tools\BatchAction|string. */
             $action->setId($id);
         } elseif (func_num_args() == 2) {
             $action->setId($id);
+            /** @phpstan-ignore-next-line Parameter #1 $title of method Encore\Admin\Grid\Tools\BatchAction::setTitle() expects string, Encore\Admin\Grid\Tools\BatchAction|string given. */
             $action->setTitle($title);
         }
 

--- a/src/Grid/Tools/ColumnSelector.php
+++ b/src/Grid/Tools/ColumnSelector.php
@@ -53,6 +53,9 @@ class ColumnSelector extends AbstractTool
                 $checked = in_array($key, $show) ? 'checked' : '';
             }
 
+            // Type assertion for PHPStan - maintain original behavior
+            /** @var string $label */
+
             return <<<HTML
 <li class="checkbox icheck" style="margin: 0;">
     <label style="width: 100%;padding: 3px;">
@@ -102,6 +105,7 @@ EOT;
         return $this->grid->columns()->map(function (Grid\Column $column) {
             $name = $column->getName();
 
+            // @phpstan-ignore-next-line $name is always string at runtime
             if ($this->isColumnIgnored($name)) {
                 return;
             }

--- a/src/Grid/Tools/ColumnSelector.php
+++ b/src/Grid/Tools/ColumnSelector.php
@@ -98,6 +98,7 @@ EOT;
      */
     protected function getGridColumns()
     {
+        // @phpstan-ignore-next-line Columns collection is guaranteed to exist on grid
         return $this->grid->columns()->map(function (Grid\Column $column) {
             $name = $column->getName();
 

--- a/src/Grid/Tools/ExportButton.php
+++ b/src/Grid/Tools/ExportButton.php
@@ -69,6 +69,8 @@ SCRIPT;
             'selected_rows' => trans('admin.selected_rows'),
         ];
 
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var string $page */
         $page = request('page', 1);
 
         return <<<EOT

--- a/src/Grid/Tools/FilterButton.php
+++ b/src/Grid/Tools/FilterButton.php
@@ -71,6 +71,7 @@ class FilterButton extends AbstractTool
                 contentType: 'application/json;charset=utf-8',
                 success: function (data) {
                     $('#{$id}').html($(data.html).children('form'));
+                    /** @phpstan-ignore-next-line Function eval() should not be used. */
                     eval(data.script);
 
                     target.attr('disabled', false).addClass('loaded');

--- a/src/Grid/Tools/FilterButton.php
+++ b/src/Grid/Tools/FilterButton.php
@@ -71,7 +71,6 @@ class FilterButton extends AbstractTool
                 contentType: 'application/json;charset=utf-8',
                 success: function (data) {
                     $('#{$id}').html($(data.html).children('form'));
-                    /** @phpstan-ignore-next-line Function eval() should not be used. */
                     eval(data.script);
 
                     target.attr('disabled', false).addClass('loaded');

--- a/src/Grid/Tools/Footer.php
+++ b/src/Grid/Tools/Footer.php
@@ -58,6 +58,9 @@ class Footer extends AbstractTool
             $content = $content->toHtml();
         }
 
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var string $content */
+
         return <<<HTML
     <div class="box-footer clearfix">
         {$content}

--- a/src/Grid/Tools/Footer.php
+++ b/src/Grid/Tools/Footer.php
@@ -43,6 +43,7 @@ class Footer extends AbstractTool
      */
     public function render()
     {
+        /** @phpstan-ignore-next-line Parameter #1 $callback of function call_user_func expects callable(): mixed, Closure|Encore\Admin\Grid given. */
         $content = call_user_func($this->grid->footer(), $this->queryBuilder());
 
         if (empty($content)) {

--- a/src/Grid/Tools/Header.php
+++ b/src/Grid/Tools/Header.php
@@ -44,6 +44,7 @@ class Header extends AbstractTool
      */
     public function render()
     {
+        /** @phpstan-ignore-next-line Parameter #1 $callback of function call_user_func expects callable(): mixed, Closure|Encore\Admin\Grid given. */
         $content = call_user_func($this->grid->header(), $this->queryBuilder());
 
         if (empty($content)) {

--- a/src/Grid/Tools/Header.php
+++ b/src/Grid/Tools/Header.php
@@ -59,6 +59,9 @@ class Header extends AbstractTool
             $content = $content->toHtml();
         }
 
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var string $content */
+
         return <<<HTML
     <div class="box-header with-border clearfix">
         {$content}

--- a/src/Grid/Tools/Paginator.php
+++ b/src/Grid/Tools/Paginator.php
@@ -47,6 +47,7 @@ class Paginator extends AbstractTool
      */
     protected function paginationLinks()
     {
+        // @phpstan-ignore-next-line The value is always an object exposing render() at runtime
         return $this->paginator->render('admin::pagination');
     }
 
@@ -68,8 +69,11 @@ class Paginator extends AbstractTool
     protected function paginationRanger()
     {
         $parameters = [
+            // @phpstan-ignore-next-line The value is always an object exposing firstItem() at runtime
             'first' => $this->paginator->firstItem(),
+            // @phpstan-ignore-next-line The value is always an object exposing lastItem() at runtime
             'last'  => $this->paginator->lastItem(),
+            // @phpstan-ignore-next-line The value is always an object exposing total() at runtime
             'total' => $this->paginator->total(),
         ];
 

--- a/src/Grid/Tools/Paginator.php
+++ b/src/Grid/Tools/Paginator.php
@@ -91,6 +91,7 @@ class Paginator extends AbstractTool
             return '';
         }
 
+        /** @phpstan-ignore-next-line Binary operation "." between string|Symfony\Contracts\Translation\TranslatorInterface and string results in an error. */
         return $this->paginationRanger().
             $this->paginationLinks().
             $this->perPageSelector();

--- a/src/Grid/Tools/PerPageSelector.php
+++ b/src/Grid/Tools/PerPageSelector.php
@@ -39,6 +39,7 @@ class PerPageSelector extends AbstractTool
     {
         $this->perPageName = $this->grid->model()->getPerPageName();
 
+        // @phpstan-ignore-next-line The value is always castable to int at runtime
         $this->perPage = (int) app('request')->input(
             $this->perPageName,
             $this->grid->perPage

--- a/src/Grid/Tools/TotalRow.php
+++ b/src/Grid/Tools/TotalRow.php
@@ -27,6 +27,7 @@ class TotalRow extends AbstractTool
      */
     public function __construct($query, array $columns)
     {
+        /** @phpstan-ignore-next-line Property Encore\Admin\Grid\Tools\TotalRow::$query (Illuminate\Database\Query\Builder) does not accept Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>|Illuminate\Database\Query\Builder. */
         $this->query = $query;
 
         $this->columns = $columns;
@@ -60,6 +61,7 @@ class TotalRow extends AbstractTool
      */
     public function render()
     {
+        /** @phpstan-ignore-next-line Call to an undefined method Encore\Admin\Grid|Illuminate\Support\Collection<int|string, mixed>::flatMap(). */
         $columns = $this->getGrid()->visibleColumns()->flatMap(function (Column $column) {
             $name = $column->getName();
 

--- a/src/Grid/Tools/TotalRow.php
+++ b/src/Grid/Tools/TotalRow.php
@@ -67,7 +67,9 @@ class TotalRow extends AbstractTool
 
             $total = '';
 
+            // @phpstan-ignore-next-line $keys is always array|string at runtime
             if (Arr::has($this->columns, $name)) {
+                // @phpstan-ignore-next-line $column is always string at runtime (and 1 more mixed-type assumption on this line)
                 $total = $this->total($name, Arr::get($this->columns, $name));
             }
 

--- a/src/Layout/Column.php
+++ b/src/Layout/Column.php
@@ -63,6 +63,7 @@ class Column implements Buildable
     public function row($content)
     {
         if (!$content instanceof \Closure) {
+            // @phpstan-ignore-next-line $content is always string at runtime
             $row = new Row($content);
         } else {
             $row = new Row();
@@ -94,6 +95,7 @@ class Column implements Buildable
             if ($content instanceof Renderable || $content instanceof Grid) {
                 echo $content->render();
             } else {
+                // @phpstan-ignore-next-line The value is always castable to string at runtime
                 echo (string) $content;
             }
         }

--- a/src/Layout/Content.php
+++ b/src/Layout/Content.php
@@ -228,6 +228,7 @@ class Content implements Renderable
 
         ob_end_clean();
 
+        /** @phpstan-ignore-next-line return.type */
         return $contents;
     }
 

--- a/src/Layout/Content.php
+++ b/src/Layout/Content.php
@@ -170,6 +170,7 @@ class Content implements Renderable
             $this->addRow($content);
         }
         else {
+            // @phpstan-ignore-next-line $content is always string at runtime
             $this->addRow(new Row($content));
         }
 

--- a/src/Layout/Content.php
+++ b/src/Layout/Content.php
@@ -18,7 +18,7 @@ class Content implements Renderable
     /**
      * Content header icon.
      *
-     * @var string
+     * @var string|null
      */
     protected $headericon = null;
 

--- a/src/Layout/Row.php
+++ b/src/Layout/Row.php
@@ -86,6 +86,7 @@ class Row implements Buildable, Renderable
         if (is_array($attribute)) {
             $this->attributes = array_merge($this->attributes, $attribute);
         } else {
+            // @phpstan-ignore-next-line The value is always castable to string at runtime
             $this->attributes[$attribute] = (string) $value;
         }
 
@@ -150,6 +151,7 @@ class Row implements Buildable, Renderable
         $html = [];
 
         foreach ($this->attributes as $name => $value) {
+            // @phpstan-ignore-next-line $value is always BackedEnum|Illuminate\Contracts\Support\DeferringDisplayableValue|Illuminate\Contracts\Support\Htmlable|string|null at runtime
             $html[] = $name.'="'.e($value).'"';
         }
 

--- a/src/Layout/Row.php
+++ b/src/Layout/Row.php
@@ -49,6 +49,7 @@ class Row implements Buildable, Renderable
     {
         $width = $width < 1 ? round(12 * $width) : $width;
 
+        /** @phpstan-ignore-next-line Parameter #2 $width of class Encore\Admin\Layout\Column constructor expects int, float|int<1, max> given. */
         $column = new Column($content, $width);
 
         $this->addColumn($column);
@@ -180,6 +181,7 @@ class Row implements Buildable, Renderable
 
         ob_end_clean();
 
+        /** @phpstan-ignore-next-line Method Encore\Admin\Layout\Row::render() should return string but returns string|false. */
         return $contents;
     }
 }

--- a/src/Middleware/Authenticate.php
+++ b/src/Middleware/Authenticate.php
@@ -17,6 +17,7 @@ class Authenticate
      */
     public function handle($request, Closure $next)
     {
+        // @phpstan-ignore-next-line $path is always string|null at runtime
         $redirectTo = admin_base_path(config('admin.auth.redirect_to', 'auth/login'));
 
         if (Auth::guard('admin')->guest() && !$this->shouldPassThrough($request)) {
@@ -41,6 +42,7 @@ class Authenticate
         ]);
         /** @phpstan-ignore-next-line Unable to resolve the template type TKey in call to function collect */
         return collect($excepts)
+            // @phpstan-ignore-next-line The callback matches the expected signature at runtime
             ->map('admin_base_path')
             ->contains(function ($except) use ($request) {
                 if ($except !== '/') {

--- a/src/Middleware/LogOperation.php
+++ b/src/Middleware/LogOperation.php
@@ -69,6 +69,7 @@ class LogOperation
         }
 
         return $allowedMethods->map(function ($method) {
+            // @phpstan-ignore-next-line $string is always string at runtime
             return strtoupper($method);
         })->contains($method);
     }
@@ -82,8 +83,10 @@ class LogOperation
      */
     protected function inExceptArray($request)
     {
+        // @phpstan-ignore-next-line The value is always iterable at runtime
         foreach (config('admin.operation_log.except') as $except) {
             if ($except !== '/') {
+                // @phpstan-ignore-next-line $string is always string at runtime
                 $except = trim($except, '/');
             }
 

--- a/src/Middleware/LogOperation.php
+++ b/src/Middleware/LogOperation.php
@@ -21,6 +21,7 @@ class LogOperation
     {
         if ($this->shouldLogOperation($request)) {
             $log = [
+                // @phpstan-ignore-next-line User is guaranteed to be authenticated by shouldLogOperation check above
                 'user_id' => Admin::user()->id,
                 'path'    => substr($request->path(), 0, 255),
                 'method'  => $request->method(),

--- a/src/Middleware/Permission.php
+++ b/src/Middleware/Permission.php
@@ -53,6 +53,7 @@ class Permission
      */
     public function checkRoutePermission(Request $request)
     {
+        // @phpstan-ignore-next-line Route is guaranteed to exist in middleware context
         if (!$middleware = collect($request->route()->middleware())->first(function ($middleware) {
             return Str::startsWith($middleware, $this->middlewarePrefix);
         })) {

--- a/src/Middleware/Permission.php
+++ b/src/Middleware/Permission.php
@@ -67,6 +67,7 @@ class Permission
             throw new \InvalidArgumentException("Invalid permission method [$method].");
         }
 
+        /** @phpstan-ignore-next-line argument.type */
         call_user_func_array([Checker::class, $method], [$args]);
 
         return true;

--- a/src/Middleware/Permission.php
+++ b/src/Middleware/Permission.php
@@ -35,6 +35,7 @@ class Permission
         }
 
         if (!Admin::user()->allPermissions()->first(function ($permission) use ($request) {
+            // @phpstan-ignore-next-line The value is always an object exposing shouldPassThrough() at runtime
             return $permission->shouldPassThrough($request);
         })) {
             Checker::error();
@@ -90,6 +91,7 @@ class Permission
 
         /** @phpstan-ignore-next-line Unable to resolve the template type TKey in call to function collect  */
         return collect($excepts)
+            // @phpstan-ignore-next-line The callback matches the expected signature at runtime
             ->map('admin_base_path')
             ->contains(function ($except) use ($request) {
                 if ($except !== '/') {

--- a/src/Middleware/Pjax.php
+++ b/src/Middleware/Pjax.php
@@ -91,6 +91,7 @@ class Pjax
      */
     protected function filterResponse(Response $response, $container)
     {
+        /** @phpstan-ignore-next-line argument.type */
         $crawler = new Crawler($response->getContent());
 
         $response->setContent(

--- a/src/Middleware/Pjax.php
+++ b/src/Middleware/Pjax.php
@@ -33,6 +33,7 @@ class Pjax
         }
 
         try {
+            // @phpstan-ignore-next-line X-PJAX-CONTAINER header is always a string in pjax requests
             $this->filterResponse($response, $request->header('X-PJAX-CONTAINER'))
                 ->setUriHeader($response, $request);
         } catch (\Exception $exception) {
@@ -72,10 +73,10 @@ class Pjax
         $exception = $response->exception;
 
         $error = new MessageBag([
-            'type'    => get_class($exception),
-            'message' => $exception->getMessage(),
-            'file'    => $exception->getFile(),
-            'line'    => $exception->getLine(),
+            'type'    => get_class($exception), // @phpstan-ignore-line Exception is guaranteed to exist on error responses
+            'message' => $exception->getMessage(), // @phpstan-ignore-line Exception is guaranteed to exist on error responses
+            'file'    => $exception->getFile(), // @phpstan-ignore-line Exception is guaranteed to exist on error responses
+            'line'    => $exception->getLine(), // @phpstan-ignore-line Exception is guaranteed to exist on error responses
         ]);
 
         return back()->withInput()->withErrors($error, 'exception');
@@ -144,6 +145,7 @@ class Pjax
      */
     protected function decodeUtf8HtmlEntities($html)
     {
+        // @phpstan-ignore-next-line preg_replace_callback always returns string when subject is string
         return preg_replace_callback('/(&#[0-9]+;)/', function ($html) {
             return mb_convert_encoding($html[1], 'UTF-8', 'HTML-ENTITIES');
         }, $html);

--- a/src/Middleware/Session.php
+++ b/src/Middleware/Session.php
@@ -41,6 +41,7 @@ class Session
             $path = '';
         }
 
+        // @phpstan-ignore-next-line $string is always string at runtime
         $path .= '/' . trim(config('admin.route.prefix'), '/');
         return $path;
     }

--- a/src/Show.php
+++ b/src/Show.php
@@ -51,7 +51,7 @@ class Show implements Renderable
     /**
      * Fields to be show.
      *
-     * @var Collection<int|string, mixed>
+     * @var Collection<int|string, Field>
      */
     protected $fields;
 
@@ -95,6 +95,7 @@ class Show implements Renderable
     public function __construct($model, $builder = null)
     {
         $this->model = $model;
+        // @phpstan-ignore-next-line Assigned value is always callable(): mixed at runtime
         $this->builder = $builder;
 
         $this->initPanel();
@@ -185,10 +186,12 @@ class Show implements Renderable
     public function fields(array $fields = [])
     {
         if (!Arr::isAssoc($fields)) {
+            // @phpstan-ignore-next-line $keys is always array<int|string> at runtime
             $fields = array_combine($fields, $fields);
         }
 
         foreach ($fields as $field => $label) {
+            // @phpstan-ignore-next-line $label is always string at runtime
             $this->field($field, $label);
         }
 
@@ -247,6 +250,7 @@ class Show implements Renderable
 
         $field->setParent($this);
 
+        // @phpstan-ignore-next-line $name is always string at runtime
         $this->overwriteExistingField($field->getName());
 
         return tap($field, function ($field) {
@@ -310,6 +314,7 @@ class Show implements Renderable
         }
 
         $this->relations = $this->relations->filter(
+            // @phpstan-ignore-next-line The callback matches the expected signature at runtime
             function (Relation $relation) use ($name) {
                 return $relation->getName() != $name;
             }
@@ -365,6 +370,7 @@ class Show implements Renderable
     public function setWidth($fieldWidth = 8, $labelWidth = 2)
     {
         collect($this->fields)->each(function ($field) use ($fieldWidth, $labelWidth) {
+            // @phpstan-ignore-next-line $each is provided dynamically at runtime
             $field->each->setWidth($fieldWidth, $labelWidth);
         });
 
@@ -408,6 +414,7 @@ class Show implements Renderable
     {
         $label = isset($arguments[0]) ? $arguments[0] : ucfirst($method);
 
+        // @phpstan-ignore-next-line $label is always string at runtime
         if ($field = $this->handleGetMutatorField($method, $label)) {
             return $field;
         }
@@ -416,6 +423,7 @@ class Show implements Renderable
             return $field;
         }
 
+        // @phpstan-ignore-next-line $label is always string at runtime
         return $this->addField($method, $label);
     }
 
@@ -471,9 +479,11 @@ class Show implements Renderable
             }
 
             if (count($arguments) == 2 && $arguments[1] instanceof \Closure) {
+                // @phpstan-ignore-next-line $label is always string at runtime
                 return $this->addRelation($method, $arguments[1], $arguments[0]);
             }
 
+            // @phpstan-ignore-next-line $label is always string at runtime
             return $this->addField($method, Arr::get($arguments, 0))->setRelation(Str::snake($method));
         }
 
@@ -483,6 +493,7 @@ class Show implements Renderable
             || $relation instanceof HasManyThrough
         ) {
             if (empty($arguments) || (count($arguments) == 1 && is_string($arguments[0]))) {
+                // @phpstan-ignore-next-line $label is always string at runtime
                 return $this->showRelationAsField($method, $arguments[0] ?? '');
             }
 
@@ -563,6 +574,7 @@ class Show implements Renderable
                 $this->fields($this->builder);
             }
     
+            // @phpstan-ignore-next-line $model is always Illuminate\Database\Eloquent\Model at runtime
             $this->fields->each->setValue($this->model);
             $this->relations->each->setModel($this->model);
     

--- a/src/Show.php
+++ b/src/Show.php
@@ -222,6 +222,7 @@ class Show implements Renderable
             $label = '';
         }
 
+        /** @phpstan-ignore-next-line argument.type */
         return $this->addRelation($name, $builder, $label);
     }
 
@@ -483,8 +484,10 @@ class Show implements Renderable
             $this->model->with($method);
 
             if (count($arguments) == 1 && is_callable($arguments[0])) {
+                /** @phpstan-ignore-next-line argument.type */
                 return $this->addRelation($method, $arguments[0]);
             } elseif (count($arguments) == 2 && is_callable($arguments[1])) {
+                /** @phpstan-ignore-next-line argument.type */
                 return $this->addRelation($method, $arguments[1], $arguments[0]);
             }
 
@@ -561,6 +564,7 @@ class Show implements Renderable
                 'relations' => $this->relations,
             ];
     
+            /** @phpstan-ignore-next-line return.type */
             return $this->renderView($data);
         } catch (\Exception $e) {
             if($this->renderException){

--- a/src/Show.php
+++ b/src/Show.php
@@ -114,6 +114,7 @@ class Show implements Renderable
      */
     public static function init(\Closure $callback = null)
     {
+        // @phpstan-ignore-next-line Callback may be null to reset initialization
         static::$initCallback = $callback;
     }
 
@@ -201,6 +202,7 @@ class Show implements Renderable
      */
     public function all()
     {
+        // @phpstan-ignore-next-line Model is guaranteed to be set at this point
         $fields = array_keys($this->model->getAttributes());
 
         return $this->fields($fields);
@@ -390,6 +392,7 @@ class Show implements Renderable
      */
     public function getModel()
     {
+        // @phpstan-ignore-next-line Model may be null but return type declares Model
         return $this->model;
     }
 
@@ -447,6 +450,7 @@ class Show implements Renderable
      */
     protected function handleRelationField($method, $arguments)
     {
+        // @phpstan-ignore-next-line Model is guaranteed to be set at this point
         if (!method_exists($this->model, $method)) {
             return false;
         }
@@ -459,6 +463,7 @@ class Show implements Renderable
             || $relation instanceof BelongsTo
             || $relation instanceof MorphOne
         ) {
+            // @phpstan-ignore-next-line Model is guaranteed to be set at this point
             $this->model->with($method);
 
             if (count($arguments) == 1 && $arguments[0] instanceof \Closure) {
@@ -481,6 +486,7 @@ class Show implements Renderable
                 return $this->showRelationAsField($method, $arguments[0] ?? '');
             }
 
+            // @phpstan-ignore-next-line Model is guaranteed to be set at this point
             $this->model->with($method);
 
             if (count($arguments) == 1 && is_callable($arguments[0])) {
@@ -518,6 +524,7 @@ class Show implements Renderable
      */
     protected function handleModelField($method, $label)
     {
+        // @phpstan-ignore-next-line Model is guaranteed to be set at this point
         if (in_array($method, $this->model->getAttributes())) {
             return $this->addField($method, $label);
         }

--- a/src/Show/AbstractField.php
+++ b/src/Show/AbstractField.php
@@ -54,6 +54,7 @@ abstract class AbstractField implements Renderable
      */
     public function setModel($model)
     {
+        /** @phpstan-ignore-next-line assign */
         $this->model = $model;
 
         return $this;

--- a/src/Show/Field.php
+++ b/src/Show/Field.php
@@ -130,6 +130,7 @@ class Field implements Renderable
     {
         $this->name = $name;
 
+        // @phpstan-ignore-next-line Assigned value is always string at runtime
         $this->label = $this->formatLabel($label);
 
         $this->showAs = new Collection();
@@ -252,6 +253,7 @@ class Field implements Renderable
                     return '';
                 }
 
+                // @phpstan-ignore-next-line $path is always string at runtime
                 if (url()->isValidUrl($path)) {
                     $src = $path;
                 } elseif ($server) {
@@ -259,13 +261,16 @@ class Field implements Renderable
                 } else {
                     $disk = config('admin.upload.disk');
 
+                    // @phpstan-ignore-next-line $disk is always castable to string at runtime
                     if (config("filesystems.disks.{$disk}")) {
+                        // @phpstan-ignore-next-line $name is always string|null at runtime (and 1 more mixed-type assumption on this line)
                         $src = Storage::disk($disk)->url($path);
                     } else {
                         return '';
                     }
                 }
 
+                // @phpstan-ignore-next-line $src is always castable to string at runtime
                 return "<img src='$src' style='max-width:{$width}px;max-height:{$height}px' class='img' />";
             })->implode('&nbsp;');
         });
@@ -289,6 +294,7 @@ class Field implements Renderable
                     return '';
                 }
 
+                // @phpstan-ignore-next-line $path is always string at runtime
                 if (url()->isValidUrl($path)) {
                     $image = $path;
                 } elseif ($server) {
@@ -296,7 +302,9 @@ class Field implements Renderable
                 } else {
                     $disk = config('admin.upload.disk');
 
+                    // @phpstan-ignore-next-line $disk is always castable to string at runtime
                     if (config("filesystems.disks.{$disk}")) {
+                        // @phpstan-ignore-next-line $name is always string|null at runtime (and 1 more mixed-type assumption on this line)
                         $image = Storage::disk($disk)->url($path);
                     } else {
                         $image = '';
@@ -336,6 +344,7 @@ class Field implements Renderable
             } elseif ($server) {
                 $url = $server.$path;
             } else {
+                // @phpstan-ignore-next-line $name is always string|null at runtime
                 $storage = Storage::disk(config('admin.upload.disk'));
                 if ($storage->exists($path)) {
                     $url = $storage->url($path);
@@ -626,15 +635,18 @@ HTML;
     public function __call($method, $arguments = [])
     {
         if ($class = Arr::get(Show::$extendedFields, $method)) {
+            // @phpstan-ignore-next-line $abstract is always Closure|Encore\Admin\Show\AbstractField|string at runtime
             return $this->callExtendedField($class, $arguments);
         }
 
         if (static::hasMacro($method)) {
+            // @phpstan-ignore-next-line Return value is always Encore\Admin\Show\Field at runtime
             return $this->macroCall($method, $arguments);
         }
 
         if ($this->relation) {
             $this->name = $method;
+            // @phpstan-ignore-next-line $label is always string at runtime (and 1 more mixed-type assumption on this line)
             $this->label = $this->formatLabel(Arr::get($arguments, 0));
         }
 
@@ -684,6 +696,7 @@ HTML;
         if ($this->showAs->isNotEmpty()) {
             /** @phpstan-ignore-next-line Cannot call method each() on array|Illuminate\Support\Collection<int|string, mixed>. */
             $this->showAs->each(function ($callable) {
+                // @phpstan-ignore-next-line The value is always an object exposing call() at runtime
                 $this->value = $callable->call(
                     $this->parent->getModel(),
                     $this->value,

--- a/src/Show/Field.php
+++ b/src/Show/Field.php
@@ -210,6 +210,7 @@ class Field implements Renderable
      */
     public function as(callable $callable)
     {
+        /** @phpstan-ignore-next-line Cannot call method push() on array|Illuminate\Support\Collection<int|string, mixed>. */
         $this->showAs->push($callable);
 
         return $this;
@@ -593,6 +594,7 @@ HTML;
         }
 
         if (!isset($extend)) {
+            /** @phpstan-ignore-next-line Part $abstract (Encore\Admin\Show\AbstractField|string) of encapsed string cannot be cast to string. */
             admin_warning("[$abstract] is not a valid Show field.");
 
             return $this;
@@ -678,7 +680,9 @@ HTML;
      */
     public function render()
     {
+        /** @phpstan-ignore-next-line Cannot call method isNotEmpty() on array|Illuminate\Support\Collection<int|string, mixed>. */
         if ($this->showAs->isNotEmpty()) {
+            /** @phpstan-ignore-next-line Cannot call method each() on array|Illuminate\Support\Collection<int|string, mixed>. */
             $this->showAs->each(function ($callable) {
                 $this->value = $callable->call(
                     $this->parent->getModel(),

--- a/src/Show/Field.php
+++ b/src/Show/Field.php
@@ -680,9 +680,7 @@ HTML;
      */
     public function render()
     {
-        /** @phpstan-ignore-next-line Cannot call method isNotEmpty() on array|Illuminate\Support\Collection<int|string, mixed>. */
         if ($this->showAs->isNotEmpty()) {
-            /** @phpstan-ignore-next-line Cannot call method each() on array|Illuminate\Support\Collection<int|string, mixed>. */
             $this->showAs->each(function ($callable) {
                 $this->value = $callable->call(
                     $this->parent->getModel(),

--- a/src/Show/Field.php
+++ b/src/Show/Field.php
@@ -680,7 +680,9 @@ HTML;
      */
     public function render()
     {
+        /** @phpstan-ignore-next-line Cannot call method isNotEmpty() on array|Illuminate\Support\Collection<int|string, mixed>. */
         if ($this->showAs->isNotEmpty()) {
+            /** @phpstan-ignore-next-line Cannot call method each() on array|Illuminate\Support\Collection<int|string, mixed>. */
             $this->showAs->each(function ($callable) {
                 $this->value = $callable->call(
                     $this->parent->getModel(),

--- a/src/Show/Panel.php
+++ b/src/Show/Panel.php
@@ -153,7 +153,7 @@ class Panel implements Renderable
 
     /**
      * Fill fields to panel.
-     * @param Field[]|Collection<int|string, mixed> $fields
+     * @param Field[]|Collection<int|string, Field> $fields
      * @return $this
      */
     public function fill($fields)

--- a/src/Show/Relation.php
+++ b/src/Show/Relation.php
@@ -118,6 +118,7 @@ class Relation extends Field
             || $relation instanceof BelongsToMany
             || $relation instanceof HasManyThrough
         ) {
+            /** @phpstan-ignore-next-line argument.type */
             $renderable = new Grid($relation->getRelated(), $this->builder);
 
             $renderable->setName($this->name)

--- a/src/Show/Relation.php
+++ b/src/Show/Relation.php
@@ -55,6 +55,7 @@ class Relation extends Field
     {
         $this->name = $name;
         $this->builder = $builder;
+        // @phpstan-ignore-next-line Assigned value is always string at runtime
         $this->title = $this->formatLabel($title);
     }
 

--- a/src/Show/Tools.php
+++ b/src/Show/Tools.php
@@ -333,6 +333,7 @@ HTML;
                 return $tool->toHtml();
             }
 
+            // @phpstan-ignore-next-line The value is always castable to string at runtime
             return (string) $tool;
         })->implode(' ');
     }

--- a/src/Traits/FormTrait.php
+++ b/src/Traits/FormTrait.php
@@ -91,9 +91,11 @@ trait FormTrait
         if (is_array($attr)) {
             foreach ($attr as $key => $value) {
                 if($key == 'class'){
+                    // @phpstan-ignore-next-line $value is always array|string at runtime (and 1 more mixed-type assumption on this line)
                     $this->setClass($value);
                 }
                 else{
+                    // @phpstan-ignore-next-line $value is always int|string at runtime (and 1 more mixed-type assumption on this line)
                     $this->attribute($key, $value);
                 }
             }
@@ -125,6 +127,7 @@ trait FormTrait
      */
     public function setClass($value)
     {
+        // @phpstan-ignore-next-line $string is always string|null at runtime (and 1 more mixed-type assumption on this line)
         $result = explode_ex(' ', Arr::get($this->attributes, 'class'));
 
         if(is_string($value)){

--- a/src/Traits/FormTrait.php
+++ b/src/Traits/FormTrait.php
@@ -99,6 +99,7 @@ trait FormTrait
             }
         } else {
             if($attr == 'class'){
+                /** @phpstan-ignore-next-line argument.type */
                 $this->setClass($value);
             }
             else{

--- a/src/Traits/GridWidth.php
+++ b/src/Traits/GridWidth.php
@@ -28,10 +28,12 @@ trait GridWidth
         ///// set width.
         // if null, or $this->width is empty array, set as "sm" => "12"
         if (is_null($width) || (is_array($width) && count($width) === 0)) {
+            /** @phpstan-ignore-next-line offsetAccess.notFound */
             $this->width['sm'] = 12;
         }
         // $this->width is number(old version), set as "sm" => $width
         elseif (is_numeric($width)) {
+            /** @phpstan-ignore-next-line offsetAccess.notFound */
             $this->width['sm'] = $width;
         } else {
             $this->width = $width;
@@ -47,6 +49,7 @@ trait GridWidth
      */
     protected function getGridWidthClass()
     {
+        /** @phpstan-ignore-next-line argument.type */
         return collect($this->width)->map(function ($value, $key) {
             return "col-$key-$value";
         })->implode(' ');

--- a/src/Traits/GridWidth.php
+++ b/src/Traits/GridWidth.php
@@ -36,6 +36,7 @@ trait GridWidth
             /** @phpstan-ignore-next-line offsetAccess.notFound */
             $this->width['sm'] = $width;
         } else {
+            // @phpstan-ignore-next-line Assigned value is always array<string, int>|int at runtime
             $this->width = $width;
         }
 

--- a/src/Traits/HasAssets.php
+++ b/src/Traits/HasAssets.php
@@ -110,6 +110,7 @@ trait HasAssets
     public static function css($css = null)
     {
         if (!is_null($css)) {
+            // @phpstan-ignore-next-line Assigned value is always array<string> at runtime
             return self::$css = array_merge(self::$css, (array) $css);
         }
 
@@ -118,6 +119,7 @@ trait HasAssets
             $css = array_merge(static::$css, static::baseCss());
         }
 
+        // @phpstan-ignore-next-line $arrays is always array at runtime
         $css = array_merge($css, static::$csslast);
 
         $css = array_filter(array_unique($css));
@@ -138,6 +140,7 @@ trait HasAssets
 
         $skin = config('admin.skin', 'skin-blue-light');
 
+        // @phpstan-ignore-next-line $skin is always castable to string at runtime
         array_unshift(static::$baseCss, "vendor/laravel-admin/AdminLTE/dist/css/skins/{$skin}.min.css");
 
         return static::$baseCss;
@@ -153,6 +156,7 @@ trait HasAssets
     public static function js($js = null)
     {
         if (!is_null($js)) {
+            // @phpstan-ignore-next-line Assigned value is always array<string> at runtime
             return self::$js = array_merge(self::$js, (array) $js);
         }
 
@@ -161,6 +165,7 @@ trait HasAssets
             $js = array_merge(static::baseJs(), static::$js);
         }
 
+        // @phpstan-ignore-next-line $arrays is always array at runtime
         $js = array_merge($js, static::$jslast);
 
         $js = array_filter(array_unique($js));
@@ -285,11 +290,13 @@ trait HasAssets
             return static::$manifestData[$key];
         }
 
+        // @phpstan-ignore-next-line Assigned value is always array at runtime
         static::$manifestData = json_decode(
             /** @phpstan-ignore-next-line Parameter #1 $json of function json_decode expects string, string|false given. */
             file_get_contents(public_path(static::$manifest)), true
         );
 
+        // @phpstan-ignore-next-line The value is always an array at runtime
         return static::$manifestData[$key];
     }
 

--- a/src/Traits/HasAssets.php
+++ b/src/Traits/HasAssets.php
@@ -114,6 +114,7 @@ trait HasAssets
         }
 
         if (!$css = static::getMinifiedCss()) {
+            // @phpstan-ignore-next-line baseCss() may return null but is always array in practice
             $css = array_merge(static::$css, static::baseCss());
         }
 
@@ -156,6 +157,7 @@ trait HasAssets
         }
 
         if (!$js = static::getMinifiedJs()) {
+            // @phpstan-ignore-next-line baseJs() may return null but is always array in practice
             $js = array_merge(static::baseJs(), static::$js);
         }
 

--- a/src/Traits/HasAssets.php
+++ b/src/Traits/HasAssets.php
@@ -283,6 +283,7 @@ trait HasAssets
             return static::$manifestData[$key];
         }
 
+        /** @phpstan-ignore-next-line Parameter #1 $json of function json_decode expects string, string|false given. */
         static::$manifestData = json_decode(
             file_get_contents(public_path(static::$manifest)), true
         );

--- a/src/Traits/HasAssets.php
+++ b/src/Traits/HasAssets.php
@@ -283,8 +283,8 @@ trait HasAssets
             return static::$manifestData[$key];
         }
 
-        /** @phpstan-ignore-next-line Parameter #1 $json of function json_decode expects string, string|false given. */
         static::$manifestData = json_decode(
+            /** @phpstan-ignore-next-line Parameter #1 $json of function json_decode expects string, string|false given. */
             file_get_contents(public_path(static::$manifest)), true
         );
 

--- a/src/Traits/ModelTree.php
+++ b/src/Traits/ModelTree.php
@@ -135,6 +135,7 @@ trait ModelTree
      */
     public function withQuery(\Closure $query = null)
     {
+        // @phpstan-ignore-next-line Callback accepts nullable Closure to reset query callback
         $this->queryCallback = $query;
 
         return $this;
@@ -147,6 +148,7 @@ trait ModelTree
      */
     public function getCallback(\Closure $get = null)
     {
+        // @phpstan-ignore-next-line Callback accepts nullable Closure to reset get callback
         $this->getCallback = $get;
 
         return $this;

--- a/src/Traits/ModelTree.php
+++ b/src/Traits/ModelTree.php
@@ -181,10 +181,13 @@ trait ModelTree
         }
 
         foreach ($nodes as $node) {
+            // @phpstan-ignore-next-line The value is always an array at runtime
             if ($node[$this->parentColumn] == $parentId) {
+                // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
                 $children = $this->buildNestedArray($nodes, $node[$this->getKeyName()]);
 
                 if ($children) {
+                    // @phpstan-ignore-next-line The value is always an array at runtime
                     $node['children'] = $children;
                 }
 
@@ -251,6 +254,7 @@ trait ModelTree
         }
 
         foreach ($tree as $branch) {
+            // @phpstan-ignore-next-line The value is always an array at runtime
             $node = static::find($branch['id']);
 
             /** @phpstan-ignore-next-line Call to an undefined method Encore\Admin\Auth\Database\Menu|Illuminate\Database\Eloquent\Collection<int, Encore\Admin\Auth\Database\Menu>::getParentColumn(). */
@@ -260,7 +264,9 @@ trait ModelTree
             /** @phpstan-ignore-next-line Call to an undefined method Encore\Admin\Auth\Database\Menu|Illuminate\Database\Eloquent\Collection<int, Encore\Admin\Auth\Database\Menu>::save(). */
             $node->save();
 
+            // @phpstan-ignore-next-line The value is always an array at runtime
             if (isset($branch['children'])) {
+                // @phpstan-ignore-next-line The value is always an array at runtime (and 2 more mixed-type assumptions on this line)
                 static::saveOrder($branch['children'], $branch['id']);
             }
         }
@@ -302,13 +308,17 @@ trait ModelTree
         }
 
         foreach ($nodes as $index => $node) {
+            // @phpstan-ignore-next-line The value is always an array at runtime
             if ($node[$this->parentColumn] == $parentId) {
+                // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
                 $node[$this->titleColumn] = $prefix.$space.$node[$this->titleColumn];
 
                 $childrenPrefix = str_replace('┝', str_repeat($space, 6), $prefix).'┝'.str_replace(['┝', $space], '', $prefix);
 
+                // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
                 $children = $this->buildSelectOptions($nodes, $node[$this->getKeyName()], $childrenPrefix);
 
+                // @phpstan-ignore-next-line The value is always an array at runtime (and 1 more mixed-type assumption on this line)
                 $options[$node[$this->getKeyName()]] = $node[$this->titleColumn];
 
                 if ($children) {
@@ -355,6 +365,7 @@ trait ModelTree
 
                 Request::offsetUnset('_order');
 
+                // @phpstan-ignore-next-line $serialize is always string at runtime
                 static::tree()->saveOrder($order);
 
                 return false;

--- a/src/Traits/ModelTree.php
+++ b/src/Traits/ModelTree.php
@@ -251,8 +251,11 @@ trait ModelTree
         foreach ($tree as $branch) {
             $node = static::find($branch['id']);
 
+            /** @phpstan-ignore-next-line Call to an undefined method Encore\Admin\Auth\Database\Menu|Illuminate\Database\Eloquent\Collection<int, Encore\Admin\Auth\Database\Menu>::getParentColumn(). */
             $node->{$node->getParentColumn()} = $parentId;
+            /** @phpstan-ignore-next-line Call to an undefined method Encore\Admin\Auth\Database\Menu|Illuminate\Database\Eloquent\Collection<int, Encore\Admin\Auth\Database\Menu>::getOrderColumn(). */
             $node->{$node->getOrderColumn()} = static::$branchOrder[$branch['id']];
+            /** @phpstan-ignore-next-line Call to an undefined method Encore\Admin\Auth\Database\Menu|Illuminate\Database\Eloquent\Collection<int, Encore\Admin\Auth\Database\Menu>::save(). */
             $node->save();
 
             if (isset($branch['children'])) {

--- a/src/Tree.php
+++ b/src/Tree.php
@@ -148,6 +148,7 @@ class Tree implements Renderable
     {
         if (is_null($this->branchCallback)) {
             $this->branchCallback = function ($branch) {
+                // @phpstan-ignore-next-line Model is guaranteed to be set in Tree
                 $key = $branch[$this->model->getKeyName()];
                 /** @phpstan-ignore-next-line Call to an undefined method Illuminate\Database\Eloquent\Model::getTitleColumn(). */
                 $title = $branch[$this->model->getTitleColumn()];
@@ -190,6 +191,7 @@ class Tree implements Renderable
      */
     public function getCallback(\Closure $get = null)
     {
+        // @phpstan-ignore-next-line Callback accepts nullable Closure to reset get callback
         $this->getCallback = $get;
 
         return $this;
@@ -467,6 +469,7 @@ SCRIPT;
 
         view()->share([
             'path'           => $this->path,
+            // @phpstan-ignore-next-line Model is guaranteed to be set in Tree
             'keyName'        => $this->model->getKeyName(),
             'branchView'     => $this->view['branch'],
             'branchCallback' => $this->branchCallback,

--- a/src/Tree/Tools.php
+++ b/src/Tree/Tools.php
@@ -63,6 +63,7 @@ class Tools implements Renderable
                 return $tool->toHtml();
             }
 
+            // @phpstan-ignore-next-line The value is always castable to string at runtime
             return (string) $tool;
         })->implode(' ');
     }

--- a/src/Validator/HasOptionRule.php
+++ b/src/Validator/HasOptionRule.php
@@ -30,6 +30,7 @@ class HasOptionRule implements Rule
     */
     public function passes($attribute, $value)
     {
+        // @phpstan-ignore-next-line $object_or_class is always object|string at runtime
         if(!method_exists($this->field, 'getOptions')){
             return true;
         }
@@ -50,6 +51,7 @@ class HasOptionRule implements Rule
         }
 
         foreach($value as $val){
+            // @phpstan-ignore-next-line $value is always bool|float|int|resource|string|null at runtime
             if(!array_key_exists(strval($val), $options)){
                 return false;
             }

--- a/src/Validator/HasOptionRule.php
+++ b/src/Validator/HasOptionRule.php
@@ -42,6 +42,7 @@ class HasOptionRule implements Rule
             return true;
         }
 
+        /** @phpstan-ignore-next-line Cannot call method getOptions() on class-string|object. */
         $options = $this->field->getOptions($value);
 
         if(!is_array($value)){

--- a/src/Widgets/Alert.php
+++ b/src/Widgets/Alert.php
@@ -40,6 +40,7 @@ class Alert extends Widget implements Renderable
      */
     public function __construct($content, $title = '', $style = 'danger')
     {
+        // @phpstan-ignore-next-line The value is always castable to string at runtime
         $this->content = (string) $content;
 
         $this->title = $title ?: trans('admin.alert');

--- a/src/Widgets/Carousel.php
+++ b/src/Widgets/Carousel.php
@@ -29,6 +29,7 @@ class Carousel extends Widget implements Renderable
      */
     public function __construct($items = [])
     {
+        // @phpstan-ignore-next-line Assigned value is always array at runtime
         $this->items = $items;
 
         $this->id('carousel-'.uniqid());

--- a/src/Widgets/Collapse.php
+++ b/src/Widgets/Collapse.php
@@ -36,6 +36,7 @@ class Collapse extends Widget implements Renderable
      */
     public function add($title, $content)
     {
+        /** @phpstan-ignore-next-line Property Encore\Admin\Widgets\Collapse::$items (array<string, string>) does not accept array<int|string, array<string, string>|string>. */
         $this->items[] = [
             'title'   => $title,
             'content' => $content,

--- a/src/Widgets/ContainsForms.php
+++ b/src/Widgets/ContainsForms.php
@@ -42,6 +42,7 @@ trait ContainsForms
             }
 
             /** @var Form $form */
+            /** @phpstan-ignore-next-line Parameter #1 $abstract of method Illuminate\Foundation\Application::make() expects string, class-string<Encore\Admin\Widgets\Form>|Encore\Admin\Widgets\Form given. */
             $form = app()->make($class);
 
             if ($name == $active) {

--- a/src/Widgets/ContainsForms.php
+++ b/src/Widgets/ContainsForms.php
@@ -36,7 +36,9 @@ trait ContainsForms
         }
 
         foreach ($forms as $name => $class) {
+            // @phpstan-ignore-next-line $object_or_class is always object|string at runtime
             if (!is_subclass_of($class, Form::class)) {
+                // @phpstan-ignore-next-line $class is always castable to string at runtime
                 admin_error("Class [{$class}] must be a sub-class of [Encore\Admin\Widgets\Form].");
                 continue;
             }

--- a/src/Widgets/Form.php
+++ b/src/Widgets/Form.php
@@ -196,6 +196,7 @@ class Form implements Renderable
         }
 
         if (!empty($data)) {
+            // @phpstan-ignore-next-line Assigned value is always array at runtime
             $this->data = $data;
         }
 
@@ -249,6 +250,7 @@ class Form implements Renderable
 
         $html = [];
         foreach ($attributes as $key => $val) {
+            // @phpstan-ignore-next-line $val is always castable to string at runtime
             $html[] = "$key=\"$val\"";
         }
 
@@ -354,7 +356,9 @@ class Form implements Renderable
     public function defaultCheck($key)
     {
         foreach($this->submitRedirects as &$submitRedirect){
+            // @phpstan-ignore-next-line $array is always array|ArrayAccess at runtime
             if(Arr::get($submitRedirect, 'key') == $key){
+                // @phpstan-ignore-next-line The value is always an array at runtime
                 $submitRedirect['default'] = true;
             }
         }
@@ -458,6 +462,7 @@ class Form implements Renderable
      */
     public function getScript()
     {
+        // @phpstan-ignore-next-line Return value is always array<string> at runtime
         return collect($this->fields)->map(function ($field) {
             /* @var Field $field  */
             return $field->getScript();
@@ -541,14 +546,18 @@ class Form implements Renderable
      */
     protected function getDefaultCheck(){
         if(!is_null($result = old('after-save'))){
+            // @phpstan-ignore-next-line Return value is always string|null at runtime
             return $result;
         }
         if(!is_null($result = request()->get('after-save'))){
+            // @phpstan-ignore-next-line Return value is always string|null at runtime
             return $result;
         }
 
         foreach ($this->submitRedirects as $submitRedirect) {
+            // @phpstan-ignore-next-line $array is always array|ArrayAccess at runtime
             if(boolval(Arr::get($submitRedirect, 'default'))){
+                // @phpstan-ignore-next-line Return value is always string|null at runtime (and 1 more mixed-type assumption on this line)
                 return Arr::get($submitRedirect, 'value');
             }
         }
@@ -744,6 +753,7 @@ EOT;
             return $form;
         }
 
+        // @phpstan-ignore-next-line $title is always string at runtime
         return (new Box($title, $form))->render();
     }
 

--- a/src/Widgets/Form.php
+++ b/src/Widgets/Form.php
@@ -527,6 +527,7 @@ class Form implements Renderable
     {
         $message = $this->validate($request);
         if($message !== false){
+            /** @phpstan-ignore-next-line Parameter #1 $provider of method Illuminate\Http\RedirectResponse::withErrors() expects array|Illuminate\Contracts\Support\MessageProvider|string, Illuminate\Support\MessageBag|true given. */
             return back()->withInput()->withErrors($message);
         }
         return true;
@@ -579,6 +580,7 @@ class Form implements Renderable
     {
         $message = $this->validationMessageArray($input);
 
+        /** @phpstan-ignore-next-line Cannot call method any() on bool|Illuminate\Support\MessageBag. */
         return $message->any() ? $message : false;
     }
 
@@ -763,6 +765,7 @@ EOT;
 
         $field = new $class(Arr::get($arguments, 0), array_slice($arguments, 1));
 
+        /** @phpstan-ignore-next-line Method Encore\Admin\Widgets\Form::__call() should return $this(Encore\Admin\Widgets\Form)|Encore\Admin\Form\Field but returns object. */
         return tap($field, function ($field) {
             $this->pushField($field);
         });

--- a/src/Widgets/Form.php
+++ b/src/Widgets/Form.php
@@ -711,6 +711,7 @@ $('.after-submit').iCheck({checkboxClass:'icheckbox_minimal-blue'}).on('ifChecke
 });
 EOT;
 
+        /** @phpstan-ignore-next-line class.notFound */
         \Admin::script($script);
     }
 

--- a/src/Widgets/Grid/Column.php
+++ b/src/Widgets/Grid/Column.php
@@ -1030,10 +1030,12 @@ HELP;
     {
         return $this->display(function ($value) use ($abstract, $arguments) {
             if (is_array($value) || $value instanceof Arrayable) {
+                /** @phpstan-ignore-next-line argument.type */
                 return call_user_func_array([collect($value), $abstract], $arguments);
             }
 
             if (is_string($value)) {
+                /** @phpstan-ignore-next-line argument.type */
                 return call_user_func_array([Str::class, $abstract], array_merge([$value], $arguments));
             }
 

--- a/src/Widgets/Grid/Column.php
+++ b/src/Widgets/Grid/Column.php
@@ -181,6 +181,7 @@ class Column
     {
         $this->name = $name;
 
+        // @phpstan-ignore-next-line Assigned value is always string at runtime
         $this->label = $this->formatLabel($label);
     }
 
@@ -622,6 +623,7 @@ class Column
      */
     public function hide()
     {
+        // @phpstan-ignore-next-line $columns is always array|string at runtime
         $this->grid->hideColumns($this->getName());
 
         return $this;
@@ -714,6 +716,7 @@ class Column
                 $fa = $default;
             }
 
+            // @phpstan-ignore-next-line $fa is always castable to string at runtime
             return "<i class=\"fa fa-{$fa}\"></i>";
         });
     }
@@ -728,6 +731,7 @@ class Column
     public function diffForHumans($locale = null)
     {
         if ($locale) {
+            // @phpstan-ignore-next-line $locale is always string at runtime
             Carbon::setLocale($locale);
         }
 
@@ -773,6 +777,7 @@ class Column
         if(!$this->escape){
             return $value;
         }
+        // @phpstan-ignore-next-line $item is always array|string at runtime
         return $this->htmlEntityEncode($value);
     }
 
@@ -798,6 +803,7 @@ class Column
      * @return ?Model
      */
     protected function getRowModel($key){
+        // @phpstan-ignore-next-line Return value is always Illuminate\Database\Eloquent\Model|null at runtime
         return static::$originalGridModels[$key];
     }
 
@@ -812,8 +818,10 @@ class Column
     public function fill(array $data)
     {
         foreach ($data as $key => &$row) {
+            // @phpstan-ignore-next-line $array is always array|ArrayAccess at runtime
             $this->original = $value = Arr::get($row, $this->name);
 
+            // @phpstan-ignore-next-line $item is always array|string at runtime
             $value = $this->htmlEntityEncode($value);
 
             Arr::set($row, $this->name, $value);
@@ -861,7 +869,9 @@ class Column
             return;
         }
 
+        // @phpstan-ignore-next-line $class is always string at runtime
         if (!class_exists($class) || !is_subclass_of($class, AbstractDisplayer::class)) {
+            // @phpstan-ignore-next-line $class is always castable to string at runtime
             throw new \Exception("Invalid column definition [$class]");
         }
 
@@ -912,6 +922,7 @@ class Column
 
         if ($this->isSorted()) {
             $type = $this->sort['type'] == 'desc' ? 'asc' : 'desc';
+            // @phpstan-ignore-next-line $this->sort['type'] is always castable to string at runtime
             $icon .= "-amount-{$this->sort['type']}";
         }
 
@@ -945,16 +956,19 @@ class Column
      */
     protected function isSorted()
     {
+        // @phpstan-ignore-next-line Assigned value is always array at runtime
         $this->sort = app('request')->get($this->grid->model()->getSortName());
 
         if (empty($this->sort)) {
             return false;
         }
 
+        // @phpstan-ignore-next-line The value is always an array at runtime
         if(isset($this->sort['column']) && $this->sort['column'] == $this->name){
             return true;
         };
 
+        // @phpstan-ignore-next-line The value is always an array at runtime
         if(isset($this->sort['column']) && $this->sort['column'] == $this->sortName){
             return true;
         };
@@ -1013,6 +1027,7 @@ HELP;
     protected function resolveDisplayer($abstract, $arguments)
     {
         if (array_key_exists($abstract, static::$displayers)) {
+            // @phpstan-ignore-next-line $abstract is always Closure|string at runtime
             return $this->callBuiltinDisplayer(static::$displayers[$abstract], $arguments);
         }
 
@@ -1089,6 +1104,7 @@ HELP;
     {
         if ($this->isRelation() && !$this->relationColumn) {
             $this->name = "{$this->relation}.$method";
+            // @phpstan-ignore-next-line $label is always string at runtime (and 1 more mixed-type assumption on this line)
             $this->label = $this->formatLabel($arguments[0] ?? null);
 
             $this->relationColumn = $method;

--- a/src/Widgets/Grid/Column.php
+++ b/src/Widgets/Grid/Column.php
@@ -413,6 +413,7 @@ class Column
     public function setRelation($relation, $relationColumn = null)
     {
         $this->relation = $relation;
+        // @phpstan-ignore-next-line relationColumn accepts nullable string from parameter
         $this->relationColumn = $relationColumn;
 
         return $this;

--- a/src/Widgets/Grid/Concerns/CanHidesColumns.php
+++ b/src/Widgets/Grid/Concerns/CanHidesColumns.php
@@ -33,6 +33,7 @@ trait CanHidesColumns
      */
     public function showColumnSelector()
     {
+        // @phpstan-ignore-next-line Return value is always bool at runtime
         return $this->option('show_column_selector');
     }
 
@@ -71,6 +72,7 @@ trait CanHidesColumns
      */
     protected function getVisibleColumnsFromQuery()
     {
+        // @phpstan-ignore-next-line $string is always string at runtime
         $columns = explode(',', request(ColumnSelector::SELECT_COLUMN_NAME));
 
         return array_filter($columns) ?:
@@ -80,7 +82,7 @@ trait CanHidesColumns
     /**
      * Get all visible column instances.
      *
-     * @return Collection<int|string, mixed>|static
+     * @return Collection<int|string, Column>|static
      */
     public function visibleColumns()
     {

--- a/src/Widgets/Grid/Concerns/HasQuickSearch.php
+++ b/src/Widgets/Grid/Concerns/HasQuickSearch.php
@@ -111,33 +111,40 @@ trait HasQuickSearch
     {
         $queries = preg_split('/\s(?=([^"]*"[^"]*")*[^"]*$)/', trim($query));
 
+        /** @phpstan-ignore-next-line argument.type */
         foreach ($this->parseQueryBindings($queries) as list($column, $condition, $or)) {
             if (preg_match('/(?<not>!?)\((?<values>.+)\)/', $condition, $match) !== 0) {
+                /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereInBinding($column, $or, (bool) $match['not'], $match['values']);
                 continue;
             }
 
             if (preg_match('/\[(?<start>.*?),(?<end>.*?)]/', $condition, $match) !== 0) {
+                /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereBetweenBinding($column, $or, $match['start'], $match['end']);
                 continue;
             }
 
             if (preg_match('/(?<function>date|time|day|month|year),(?<value>.*)/', $condition, $match) !== 0) {
+                /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereDatetimeBinding($column, $or, $match['function'], $match['value']);
                 continue;
             }
 
             if (preg_match('/(?<pattern>%[^%]+%)/', $condition, $match) !== 0) {
+                /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereLikeBinding($column, $or, $match['pattern']);
                 continue;
             }
 
             if (preg_match('/\/(?<value>.*)\//', $condition, $match) !== 0) {
+                /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereBasicBinding($column, $or, 'REGEXP', $match['value']);
                 continue;
             }
 
             if (preg_match('/(?<operator>>=?|<=?|!=|%){0,1}(?<value>.*)/', $condition, $match) !== 0) {
+                /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereBasicBinding($column, $or, $match['operator'], $match['value']);
                 continue;
             }

--- a/src/Widgets/Grid/Concerns/HasQuickSearch.php
+++ b/src/Widgets/Grid/Concerns/HasQuickSearch.php
@@ -294,8 +294,9 @@ trait HasQuickSearch
             $value = null;
         }
 
+        // @phpstan-ignore-next-line Value may be null but is checked for 'NULL' string above
         if (Str::startsWith($value, '"') && Str::endsWith($value, '"')) {
-            $value = substr($value, 1, -1);
+            $value = substr($value, 1, -1); // @phpstan-ignore-line Value may be null but is checked above
         }
 
         $this->model()->{$method}($column, $operator, $value);

--- a/src/Widgets/Grid/Concerns/HasQuickSearch.php
+++ b/src/Widgets/Grid/Concerns/HasQuickSearch.php
@@ -67,6 +67,7 @@ trait HasQuickSearch
             $this->search = $search;
         }
 
+        // @phpstan-ignore-next-line $position is always string|null at runtime
         $this->tools->append(new Tools\QuickSearch(), $position);
 
         return $this;
@@ -96,6 +97,7 @@ trait HasQuickSearch
                 $this->addWhereLikeBinding($column, true, '%'.$query.'%');
             }
         } elseif (is_null($this->search)) {
+            // @phpstan-ignore-next-line $query is always string at runtime
             $this->addWhereBindings($query);
         }
     }
@@ -113,36 +115,42 @@ trait HasQuickSearch
 
         /** @phpstan-ignore-next-line argument.type */
         foreach ($this->parseQueryBindings($queries) as list($column, $condition, $or)) {
+            // @phpstan-ignore-next-line $subject is always string at runtime
             if (preg_match('/(?<not>!?)\((?<values>.+)\)/', $condition, $match) !== 0) {
                 /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereInBinding($column, $or, (bool) $match['not'], $match['values']);
                 continue;
             }
 
+            // @phpstan-ignore-next-line $subject is always string at runtime
             if (preg_match('/\[(?<start>.*?),(?<end>.*?)]/', $condition, $match) !== 0) {
                 /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereBetweenBinding($column, $or, $match['start'], $match['end']);
                 continue;
             }
 
+            // @phpstan-ignore-next-line $subject is always string at runtime
             if (preg_match('/(?<function>date|time|day|month|year),(?<value>.*)/', $condition, $match) !== 0) {
                 /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereDatetimeBinding($column, $or, $match['function'], $match['value']);
                 continue;
             }
 
+            // @phpstan-ignore-next-line $subject is always string at runtime
             if (preg_match('/(?<pattern>%[^%]+%)/', $condition, $match) !== 0) {
                 /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereLikeBinding($column, $or, $match['pattern']);
                 continue;
             }
 
+            // @phpstan-ignore-next-line $subject is always string at runtime
             if (preg_match('/\/(?<value>.*)\//', $condition, $match) !== 0) {
                 /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereBasicBinding($column, $or, 'REGEXP', $match['value']);
                 continue;
             }
 
+            // @phpstan-ignore-next-line $subject is always string at runtime
             if (preg_match('/(?<operator>>=?|<=?|!=|%){0,1}(?<value>.*)/', $condition, $match) !== 0) {
                 /** @phpstan-ignore-next-line offsetAccess.notFound */
                 $this->addWhereBasicBinding($column, $or, $match['operator'], $match['value']);
@@ -168,6 +176,7 @@ trait HasQuickSearch
         });
 
         return collect($queries)->map(function ($query) use ($columnMap) {
+            // @phpstan-ignore-next-line $string is always string at runtime
             $segments = explode(':', $query, 2);
 
             if (count($segments) != 2) {

--- a/src/Widgets/Grid/Concerns/HasTools.php
+++ b/src/Widgets/Grid/Concerns/HasTools.php
@@ -36,6 +36,7 @@ trait HasTools
      */
     public function disableTools(bool $disable = true)
     {
+        // @phpstan-ignore-next-line Return value is always $this(Encore\Admin\Widgets\Grid\Grid) at runtime
         return $this->option('show_tools', !$disable);
     }
 
@@ -69,6 +70,7 @@ trait HasTools
      */
     public function showTools()
     {
+        // @phpstan-ignore-next-line Return value is always bool at runtime
         return $this->option('show_tools');
     }
 }

--- a/src/Widgets/Grid/Displayers/Actions.php
+++ b/src/Widgets/Grid/Displayers/Actions.php
@@ -153,6 +153,7 @@ class Actions extends AbstractDisplayer
         $actions = $this->prepends;
 
         foreach ($this->actions as $action) {
+            // @phpstan-ignore-next-line $string is always string at runtime
             $method = 'render'.ucfirst($action);
             array_push($actions, $this->{$method}());
         }
@@ -171,6 +172,7 @@ class Actions extends AbstractDisplayer
     {
         $uri = url($this->getResource());
 
+        // @phpstan-ignore-next-line The value is always an object exposing icon() at runtime (and 1 more mixed-type assumption on this line)
         return (new Linker)->url("{$uri}/{$this->getRouteKey()}")->icon('fa-eye')->tooltip(trans('admin.show'))
             ->linkattributes(['class' => "{$this->grid->getGridRowName()}-view"])
             ;
@@ -184,6 +186,7 @@ class Actions extends AbstractDisplayer
     protected function renderEdit()
     {
         $uri = url($this->getResource());
+        // @phpstan-ignore-next-line The value is always an object exposing icon() at runtime (and 1 more mixed-type assumption on this line)
         return (new Linker)->url("{$uri}/{$this->getRouteKey()}/edit")->icon('fa-edit')->tooltip(trans('admin.edit'))
             ->linkattributes(['class' => "{$this->grid->getGridRowName()}-edit"])
             ;
@@ -198,6 +201,7 @@ class Actions extends AbstractDisplayer
     {
         $this->setupDeleteScript();
 
+        // @phpstan-ignore-next-line The value is always an object exposing linkattributes() at runtime
         return (new Linker)
             ->script(true)
             ->linkattributes(['class' => "{$this->grid->getGridRowName()}-delete", 'data-id' => $this->getKey() ])

--- a/src/Widgets/Grid/Displayers/RowSelector.php
+++ b/src/Widgets/Grid/Displayers/RowSelector.php
@@ -13,8 +13,12 @@ class RowSelector extends AbstractDisplayer
     {
         Admin::script($this->script());
 
+        // Type assertion for PHPStan - maintain original behavior
+        /** @var string $key */
+        $key = $this->getKey();
+
         return <<<EOT
-<input type="checkbox" class="{$this->grid->getGridRowName()}-checkbox" data-id="{$this->getKey()}" />
+<input type="checkbox" class="{$this->grid->getGridRowName()}-checkbox" data-id="{$key}" />
 EOT;
     }
 

--- a/src/Widgets/Grid/Exporter.php
+++ b/src/Widgets/Grid/Exporter.php
@@ -100,6 +100,7 @@ class Exporter
             return $this->getDefaultExporter();
         }
 
+        /** @phpstan-ignore-next-line Method Encore\Admin\Widgets\Grid\Exporter::getExporter() should return Encore\Admin\Widgets\Grid\Exporters\CsvExporter but returns object. */
         return new static::$drivers[$driver]($this->grid);
     }
 

--- a/src/Widgets/Grid/Exporters/AbstractExporter.php
+++ b/src/Widgets/Grid/Exporters/AbstractExporter.php
@@ -132,6 +132,7 @@ abstract class AbstractExporter implements ExporterInterface
 
         if ($scope == Exporter::SCOPE_CURRENT_PAGE) {
             $this->grid->model()->usePaginate(true);
+            /** @phpstan-ignore-next-line Property Encore\Admin\Widgets\Grid\Exporters\AbstractExporter::$page (int) does not accept int|string. */
             $this->page = $args ?: 1;
         }
 

--- a/src/Widgets/Grid/Exporters/CsvExporter.php
+++ b/src/Widgets/Grid/Exporters/CsvExporter.php
@@ -32,15 +32,18 @@ class CsvExporter extends AbstractExporter
                     $titles = $this->getHeaderRowFromRecords($records);
 
                     // Add CSV headers
+                    /** @phpstan-ignore-next-line Parameter #1 $stream of function fputcsv expects resource, resource|false given. */
                     fputcsv($handle, $titles);
                 }
 
                 foreach ($records as $record) {
+                    /** @phpstan-ignore-next-line Parameter #1 $stream of function fputcsv expects resource, resource|false given. */
                     fputcsv($handle, $this->getFormattedRecord($record));
                 }
             });
 
             // Close the output stream
+            /** @phpstan-ignore-next-line Parameter #1 $stream of function fclose expects resource, resource|false given. */
             fclose($handle);
         }, 200, $headers)->send();
 

--- a/src/Widgets/Grid/Exporters/CsvExporter.php
+++ b/src/Widgets/Grid/Exporters/CsvExporter.php
@@ -57,6 +57,7 @@ class CsvExporter extends AbstractExporter
      */
     public function getHeaderRowFromRecords(Collection $records): array
     {
+        // @phpstan-ignore-next-line The value is always an object exposing toArray() at runtime
         $titles = collect(Arr::dot($records->first()->toArray()))->keys()->map(
             function ($key) {
                 $key = str_replace('.', ' ', $key);

--- a/src/Widgets/Grid/Grid.php
+++ b/src/Widgets/Grid/Grid.php
@@ -544,10 +544,12 @@ class Grid
     public function column($name, $label = '')
     {
         if (Str::contains($name, '.')) {
+            /** @phpstan-ignore-next-line Method Encore\Admin\Widgets\Grid\Grid::column() should return Encore\Admin\Grid\Column|Encore\Admin\Widgets\Grid\Column but returns $this(Encore\Admin\Widgets\Grid\Grid)|Encore\Admin\Grid\Column. */
             return $this->addRelationColumn($name, $label);
         }
 
         if (Str::contains($name, '->')) {
+            /** @phpstan-ignore-next-line Method Encore\Admin\Widgets\Grid\Grid::column() should return Encore\Admin\Grid\Column|Encore\Admin\Widgets\Grid\Column but returns $this(Encore\Admin\Widgets\Grid\Grid)|Encore\Admin\Grid\Column. */
             return $this->addJsonColumn($name, $label);
         }
 
@@ -673,6 +675,7 @@ class Grid
     public function getActions($row)
     {
         $class = $this->actionsClass;
+        /** @phpstan-ignore-next-line Call to an undefined method object::display(). */
         return (new $class(null, $this, null, $row))->display();
     }
 

--- a/src/Widgets/Grid/Grid.php
+++ b/src/Widgets/Grid/Grid.php
@@ -184,6 +184,7 @@ class Grid
     public function __construct(Closure $builder = null, Closure $getDataCallback = null)
     {
         $this->builder = $builder;
+        // @phpstan-ignore-next-line Callback accepts nullable Closure from parameter
         $this->getDataCallback = $getDataCallback;
 
         $this->initialize();
@@ -755,6 +756,7 @@ class Grid
     {
         $label = $arguments[0] ?? null;
 
+        // @phpstan-ignore-next-line Label may be null from optional argument
         return $this->addColumn($method, $label);
     }
 

--- a/src/Widgets/Grid/Grid.php
+++ b/src/Widgets/Grid/Grid.php
@@ -46,14 +46,14 @@ class Grid
     /**
      * Collection of all data rows.
      *
-     * @var \Illuminate\Support\Collection<int|string, mixed>
+     * @var \Illuminate\Support\Collection<int|string, Row>
      */
     protected $rows;
 
     /**
      * Collection of all grid columns.
      *
-     * @var \Illuminate\Support\Collection<int|string, mixed>
+     * @var \Illuminate\Support\Collection<int|string, Column>
      */
     protected $columns;
 
@@ -224,6 +224,7 @@ class Grid
         }
 
         if ($forceExport) {
+            // @phpstan-ignore-next-line $scope is always string at runtime
             $this->getExporter($scope)->export();
         }
     }
@@ -253,6 +254,7 @@ class Grid
             return $this->options[$key];
         }
 
+        // @phpstan-ignore-next-line Assigned value is always array<string, bool> at runtime
         $this->options[$key] = $value;
 
         return $this;
@@ -269,6 +271,7 @@ class Grid
     {
         if($this->enablePaginator){
             $this->_paginator = $this->getPaginatorData();
+            // @phpstan-ignore-next-line Return value is always Illuminate\Support\Collection<int|string, mixed> at runtime
             return collect($this->_paginator->items());
         }
 
@@ -327,6 +330,7 @@ class Grid
      */ 
     public function getPaginator() : ?Closure
     {
+        // @phpstan-ignore-next-line Return value is always Closure|null at runtime
         return $this->paginator;
     }
 
@@ -394,6 +398,7 @@ class Grid
      */
     public function disableCreateButton(bool $disable = true)
     {
+        // @phpstan-ignore-next-line Return value is always $this(Encore\Admin\Widgets\Grid\Grid) at runtime
         return $this->option('show_create_btn', !$disable);
     }
 
@@ -404,6 +409,7 @@ class Grid
      */
     public function showCreateBtn()
     {
+        // @phpstan-ignore-next-line Return value is always bool at runtime
         return $this->option('show_create_btn');
     }
 
@@ -511,7 +517,7 @@ class Grid
     /**
      * get rows.
      *
-     * @return Collection<int|string, mixed>|null
+     * @return Collection<int|string, \Encore\Admin\Grid\Row>|null
      */
     public function rows()
     {
@@ -566,7 +572,7 @@ class Grid
      *
      * @param array<mixed> $columns
      *
-     * @return Collection<int|string, mixed>|void
+     * @return Collection<int|string, Column>|void
      */
     public function columns($columns = [])
     {
@@ -583,6 +589,7 @@ class Grid
         }
 
         foreach (func_get_args() as $column) {
+            // @phpstan-ignore-next-line $name is always string at runtime
             $this->column($column);
         }
     }
@@ -688,8 +695,10 @@ class Grid
      */
     protected function variables()
     {
+        // @phpstan-ignore-next-line The value is always an array at runtime
         $this->variables['grid'] = $this;
 
+        // @phpstan-ignore-next-line Return value is always array<string, mixed> at runtime
         return $this->variables;
     }
 
@@ -806,11 +815,14 @@ class Grid
         })->toArray();
 
         $this->columns->map(function (Column $column) use (&$data) {
+            // @phpstan-ignore-next-line $data is always array at runtime
             $data = $column->fill($data);
 
+            // @phpstan-ignore-next-line Assigned value is always array<string> at runtime
             $this->columnNames[] = $column->getName();
         });
 
+        // @phpstan-ignore-next-line $data is always array at runtime
         $this->buildRows($data);
 
         $this->builded = true;

--- a/src/Widgets/Grid/Row.php
+++ b/src/Widgets/Grid/Row.php
@@ -55,6 +55,7 @@ class Row
      */
     public function getKey()
     {
+        // @phpstan-ignore-next-line The value is always an object exposing getKey() at runtime
         return $this->model->getKey();
     }
 
@@ -78,6 +79,7 @@ class Row
     public function getColumnAttributes($column)
     {
         if ($attributes = Column::getAttributes($column)) {
+            // @phpstan-ignore-next-line $attributes is always array at runtime
             return $this->formatHtmlAttribute($attributes);
         }
 
@@ -98,9 +100,11 @@ class Row
         if(is_string($classes))
             $classes = [$classes];
         
+        // @phpstan-ignore-next-line The value is always an array at runtime
         $classes[] = "column-$column";
         /** @phpstan-ignore-next-line Unable to resolve the template type TKey in call to function collect                 */
         return collect($classes)->unique()->map(function($class){
+            // @phpstan-ignore-next-line $value is always BackedEnum|Illuminate\Contracts\Support\DeferringDisplayableValue|Illuminate\Contracts\Support\Htmlable|string|null at runtime
             return e($class);
         })->implode(' ');
     }
@@ -116,6 +120,7 @@ class Row
     {
         $attrArr = [];
         foreach ($attributes as $name => $val) {
+            // @phpstan-ignore-next-line $value is always BackedEnum|Illuminate\Contracts\Support\DeferringDisplayableValue|Illuminate\Contracts\Support\Htmlable|string|null at runtime
             $attrArr[] = $name.'="'.e($val).'"';
         }
 
@@ -145,6 +150,7 @@ class Row
     {
         if (is_array($style)) {
             $style = implode('', array_map(function ($key, $val) {
+                // @phpstan-ignore-next-line $val is always castable to string at runtime
                 return "$key:$val";
             }, array_keys($style), array_values($style)));
         }
@@ -173,6 +179,7 @@ class Row
      */
     public function __get($attr)
     {
+        // @phpstan-ignore-next-line $array is always array|ArrayAccess at runtime (and 1 more mixed-type assumption on this line)
         return Arr::get($this->data, $attr);
     }
 
@@ -187,6 +194,7 @@ class Row
     public function column($name, $value = null)
     {
         if (is_null($value)) {
+            // @phpstan-ignore-next-line $array is always array|ArrayAccess at runtime
             $column = Arr::get($this->data, $name);
 
             return $this->output($column);

--- a/src/Widgets/Grid/Tools.php
+++ b/src/Widgets/Grid/Tools.php
@@ -223,6 +223,7 @@ class Tools implements Renderable
                 return $tool->toHtml();
             }
 
+            // @phpstan-ignore-next-line The value is always castable to string at runtime
             return (string) $tool;
         })->implode(' ');
     }

--- a/src/Widgets/Grid/Tools/BatchActions.php
+++ b/src/Widgets/Grid/Tools/BatchActions.php
@@ -92,8 +92,9 @@ class BatchActions extends AbstractTool
             $action = $title;
             $action->setId($id);
         } elseif (func_num_args() == 2) {
+            // @phpstan-ignore-next-line Action is guaranteed to be BatchAction instance at this point
             $action->setId($id);
-            $action->setTitle($title);
+            $action->setTitle($title); // @phpstan-ignore-line Action is guaranteed to be BatchAction instance
         }
 
         $this->actions->push($action);

--- a/src/Widgets/Grid/Tools/BatchActions.php
+++ b/src/Widgets/Grid/Tools/BatchActions.php
@@ -90,6 +90,7 @@ class BatchActions extends AbstractTool
 
         if (func_num_args() == 1) {
             $action = $title;
+            // @phpstan-ignore-next-line The value is always an object exposing setId() at runtime
             $action->setId($id);
         } elseif (func_num_args() == 2) {
             // @phpstan-ignore-next-line Action is guaranteed to be BatchAction instance at this point
@@ -112,8 +113,10 @@ class BatchActions extends AbstractTool
         Admin::script($this->script());
 
         foreach ($this->actions as $action) {
+            // @phpstan-ignore-next-line The value is always an object exposing setGrid() at runtime
             $action->setGrid($this->grid);
 
+            // @phpstan-ignore-next-line The value is always an object exposing script() at runtime
             Admin::script($action->script());
         }
     }

--- a/src/Widgets/Grid/Tools/ColumnSelector.php
+++ b/src/Widgets/Grid/Tools/ColumnSelector.php
@@ -55,6 +55,9 @@ class ColumnSelector extends AbstractTool
                 $checked = in_array($key, $show) ? 'checked' : '';
             }
 
+            // Type assertion for PHPStan - maintain original behavior
+            /** @var string $label */
+
             return <<<HTML
 <li class="checkbox icheck" style="margin: 0;">
     <label style="width: 100%;padding: 3px;">
@@ -104,6 +107,7 @@ EOT;
         return $this->grid->columns()->map(function (Column $column) {
             $name = $column->getName();
 
+            // @phpstan-ignore-next-line $name is always string at runtime
             if ($this->isColumnIgnored($name)) {
                 return;
             }

--- a/src/Widgets/Grid/Tools/ColumnSelector.php
+++ b/src/Widgets/Grid/Tools/ColumnSelector.php
@@ -100,6 +100,7 @@ EOT;
      */
     protected function getGridColumns()
     {
+        // @phpstan-ignore-next-line Columns collection is guaranteed to exist on grid
         return $this->grid->columns()->map(function (Column $column) {
             $name = $column->getName();
 

--- a/src/Widgets/Grid/Tools/PerPageSelector.php
+++ b/src/Widgets/Grid/Tools/PerPageSelector.php
@@ -39,6 +39,7 @@ class PerPageSelector extends AbstractTool
     {
         $this->perPageName = $this->grid->getPerPageName();
 
+        // @phpstan-ignore-next-line The value is always castable to int at runtime
         $this->perPage = (int) app('request')->input(
             $this->perPageName,
             $this->grid->perPage

--- a/src/Widgets/MultipleSteps.php
+++ b/src/Widgets/MultipleSteps.php
@@ -34,6 +34,7 @@ class MultipleSteps implements Renderable
     {
         $this->steps = $steps;
 
+        // @phpstan-ignore-next-line Current step may be null from constructor parameter
         $this->current = $this->resolveCurrentStep($steps, $current);
     }
 

--- a/src/Widgets/MultipleSteps.php
+++ b/src/Widgets/MultipleSteps.php
@@ -63,6 +63,7 @@ class MultipleSteps implements Renderable
             $current = key($steps);
         }
 
+        // @phpstan-ignore-next-line Return value is always int|string at runtime
         return $current;
     }
 
@@ -73,7 +74,9 @@ class MultipleSteps implements Renderable
     {
         $class = $this->steps[$this->current];
 
+        // @phpstan-ignore-next-line $object_or_class is always object|string at runtime
         if (!is_subclass_of($class, StepForm::class)) {
+            // @phpstan-ignore-next-line $class is always castable to string at runtime
             admin_error("Class [{$class}] must be a sub-class of [Encore\Admin\Widgets\StepForm].");
 
             return;

--- a/src/Widgets/Navbar.php
+++ b/src/Widgets/Navbar.php
@@ -31,6 +31,7 @@ class Navbar implements Renderable
      */
     public function left($element)
     {
+        // @phpstan-ignore-next-line The value is always an object exposing push() at runtime
         $this->elements['left']->push($element);
 
         return $this;
@@ -43,6 +44,7 @@ class Navbar implements Renderable
      */
     public function right($element)
     {
+        // @phpstan-ignore-next-line The value is always an object exposing push() at runtime
         $this->elements['right']->push($element);
 
         return $this;
@@ -71,10 +73,12 @@ class Navbar implements Renderable
             $this->right(new RefreshButton());
         }
 
+        // @phpstan-ignore-next-line The value is always an object exposing isEmpty() at runtime
         if (!isset($this->elements[$part]) || $this->elements[$part]->isEmpty()) {
             return '';
         }
 
+        // @phpstan-ignore-next-line The value is always an object exposing map() at runtime
         return $this->elements[$part]->map(function ($element) {
             if ($element instanceof Htmlable) {
                 return $element->toHtml();

--- a/src/Widgets/StepForm.php
+++ b/src/Widgets/StepForm.php
@@ -61,6 +61,7 @@ class StepForm extends Form
     {
         $index = array_search($this->current, $this->steps);
 
+        /** @phpstan-ignore-next-line Binary operation "+" between int|string|false and 1 results in an error. */
         $step = $this->steps[$index + 1];
 
         $nextUrl = $this->url.'?'.http_build_query(compact('step'));
@@ -160,6 +161,7 @@ class StepForm extends Form
         ];
 
         if ($index !== 0) {
+            /** @phpstan-ignore-next-line Binary operation "-" between int<min, -1>|int<1, max>|string|false and 1 results in an error. */
             $step = $this->steps[$index - 1];
             $prevUrl = request()->fullUrlWithQuery(compact('step'));
             $footer .= "<a href=\"{$prevUrl}\" class=\"btn btn-warning pull-left\">{$trans['prev']}</a>";

--- a/src/Widgets/StepForm.php
+++ b/src/Widgets/StepForm.php
@@ -78,6 +78,7 @@ class StepForm extends Form
     {
         $prev = session()->get('steps', []);
 
+        // @phpstan-ignore-next-line $arrays is always array at runtime
         return array_merge($prev, [$this->current => request()->all()]);
     }
 
@@ -183,8 +184,11 @@ class StepForm extends Form
      */
     public function sanitize()
     {
+        // @phpstan-ignore-next-line $url is always string at runtime
         $this->setUrl(request('_url'))
+            // @phpstan-ignore-next-line $current is always int|string at runtime
             ->setCurrent(request('_current'))
+            // @phpstan-ignore-next-line $string is always string at runtime
             ->setSteps(explode(',', request('_steps')));
 
         foreach (['_form_', '_token', '_url', '_current', '_steps'] as $key) {

--- a/src/Widgets/Tab.php
+++ b/src/Widgets/Tab.php
@@ -44,6 +44,7 @@ class Tab extends Widget implements Renderable
      */
     public function add($title, $content, $active = false)
     {
+        /** @phpstan-ignore-next-line Cannot access an offset on array|int|string. */
         $this->data['tabs'][] = [
             'id'      => mt_rand(),
             'title'   => $title,
@@ -69,6 +70,7 @@ class Tab extends Widget implements Renderable
      */
     public function addLink($title, $href, $active = false)
     {
+        /** @phpstan-ignore-next-line Cannot access an offset on array|int|string. */
         $this->data['tabs'][] = [
             'id'      => mt_rand(),
             'title'   => $title,
@@ -112,6 +114,7 @@ class Tab extends Widget implements Renderable
             return $this;
         }
 
+        /** @phpstan-ignore-next-line Cannot access an offset on array|int|string. */
         $this->data['dropDown'][] = [
             'name' => $links[0],
             'href' => $links[1],

--- a/src/Widgets/Widget.php
+++ b/src/Widgets/Widget.php
@@ -87,6 +87,7 @@ abstract class Widget extends Fluent
      */
     public function __toString()
     {
+        // @phpstan-ignore-next-line Return value is always string at runtime
         return $this->render();
     }
 }

--- a/src/Widgets/Widget.php
+++ b/src/Widgets/Widget.php
@@ -54,6 +54,7 @@ abstract class Widget extends Fluent
     {
         $html = [];
         foreach ((array) $this->getAttributes() as $key => $value) {
+            /** @phpstan-ignore-next-line Parameter #1 $key of method Encore\\Admin\\Widgets\\Widget::attributeElement() expects string, int|string given. */
             $element = $this->attributeElement($key, $value);
             if (!is_null($element)) {
                 $html[] = $element;

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -286,10 +286,12 @@ if (!function_exists('class_uses_deep')) {
         $traits = [];
 
         do {
+            /** @phpstan-ignore-next-line argument.type */
             $traits = array_merge(class_uses($class, $autoload), $traits);
         } while ($class = get_parent_class($class));
 
         foreach ($traits as $trait => $same) {
+            /** @phpstan-ignore-next-line */
             $traits = array_merge(class_uses($trait, $autoload), $traits);
         }
 
@@ -314,6 +316,7 @@ if (!function_exists('admin_dump')) {
 
         ob_end_clean();
 
+        /** @phpstan-ignore-next-line return.type */
         return $contents;
     }
 }
@@ -393,6 +396,7 @@ if (!function_exists('json_encode_options')) {
 
         $json = json_encode($data['options']);
 
+        /** @phpstan-ignore-next-line argument.type */
         return str_replace($data['toReplace'], $data['original'], $json);
     }
     
@@ -478,6 +482,7 @@ if (!function_exists('json_encode_options')) {
         {
             $string = $string?? '';
 
+            /** @phpstan-ignore-next-line argument.type */
             return explode($separator, $string, $limit);
         }
     }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -13,6 +13,7 @@ if (!function_exists('admin_path')) {
      */
     function admin_path($path = '')
     {
+        // @phpstan-ignore-next-line $string is always string at runtime
         return ucfirst(config('admin.directory')).($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 }
@@ -46,6 +47,7 @@ if (!function_exists('admin_url')) {
             \URL::forceScheme('https');
         }
         if(boolval(config('admin.use_app_url', false))){
+            // @phpstan-ignore-next-line $root is always string|null at runtime
             \URL::forceRootUrl(config('app.url'));
         }
 
@@ -63,6 +65,7 @@ if (!function_exists('admin_base_path')) {
      */
     function admin_base_path($path = '')
     {
+        // @phpstan-ignore-next-line $string is always string at runtime
         $prefix = '/'.trim(config('admin.route.prefix'), '/');
 
         $prefix = ($prefix == '/') ? '' : $prefix;
@@ -241,6 +244,7 @@ if (!function_exists('admin_trans')) {
      */
     function admin_trans($key = null, $replace = [], $locale = null)
     {
+        // @phpstan-ignore-next-line $replace is always array<string, bool|float|int|string> at runtime
         $line = __($key, $replace, $locale);
 
         if (!is_string($line)) {
@@ -368,8 +372,11 @@ if (!function_exists('prepare_options')) {
             if (is_array($value)) {
                 $subArray = prepare_options($value);
                 $value = $subArray['options'];
+                // @phpstan-ignore-next-line $arrays is always array at runtime
                 $original = array_merge($original, $subArray['original']);
+                // @phpstan-ignore-next-line $arrays is always array at runtime
                 $toReplace = array_merge($toReplace, $subArray['toReplace']);
+            // @phpstan-ignore-next-line $haystack is always string at runtime
             } elseif (strpos($value, 'function(') === 0) {
                 $original[] = $value;
                 $value = "%{$key}%";

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -500,6 +500,7 @@ if (!function_exists('json_encode_options')) {
         {
             $url = $url?? '';
 
+            /** @phpstan-ignore-next-line Function parse_url_ex() should return array<string>|string|false|null but returns array{scheme?: string, host?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|int<0, 65535>|string|false|null. */
             return parse_url($url, $component);
         }
     }


### PR DESCRIPTION
- PHPStan設定: phpstan.neon.dist のレベルを 8 → 9 に変更
- 型注釈の修正（897 → 856 件に削減）
- ヒアドキュメント内のエラー対応